### PR TITLE
Improve reply analytics and interactive filtering

### DIFF
--- a/services/api/kpis.py
+++ b/services/api/kpis.py
@@ -119,15 +119,11 @@ def compute(df: pd.DataFrame) -> Dict[str, Any]:
         "words": int(by_sender_df["words"].sum()) if len(by_sender_df)>0 else 0
     }
 
-    # Reply stats (general next-other-sender, fallback to adjacent)
-    rp = reply_pairs_general(d)
-    if rp.empty:
-        rp_adj = reply_pairs(d)
-        if not rp_adj.empty:
-            rp = rp_adj.rename(columns={"to":"responder"})
+    # Reply stats (adjacent messages by different senders)
+    rp = reply_pairs(d)
     reply_simple = []
     if not rp.empty:
-        for person, arr in rp.groupby("responder")["sec"]:
+        for person, arr in rp.groupby("to")["sec"]:
             arr = arr.clip(lower=0)
             reply_simple.append({
                 "person": str(person),

--- a/web/components/Card.tsx
+++ b/web/components/Card.tsx
@@ -1,7 +1,8 @@
 import { ReactNode } from "react";
-export default function Card({ title, children }: { title: string; children: ReactNode }) {
+
+export default function Card({ title, children, tooltip }: { title: string; children: ReactNode; tooltip?: string }) {
   return (
-    <div className="rounded-2xl bg-white/5 backdrop-blur border border-white/10 p-4 shadow-sm">
+    <div className="rounded-2xl bg-white/5 backdrop-blur border border-white/10 p-4 shadow-sm" title={tooltip}>
       <div className="text-sm text-gray-300 mb-2">{title}</div>
       <div>{children}</div>
     </div>


### PR DESCRIPTION
## Summary
- fix reply time median/mean calculation using adjacent messages
- add tooltip descriptions and date range filters to dashboard
- enable interactive timeline zoom for better exploration

## Testing
- `npm run build`
- `python -m py_compile services/api/kpis.py`

------
https://chatgpt.com/codex/tasks/task_e_68964fb100d083258196d8ab695011ac