### PR TITLE
style: align heatmap colors with dashboard palette

### DIFF
--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -190,7 +190,7 @@ export default function Home() {
       tooltip: {},
       xAxis: { type: "category", data: hours, axisLabel:{color: palette.text}, axisLine:{lineStyle:{color: palette.subtext}} },
       yAxis: { type: "category", data: weekdays, axisLabel:{color: palette.text}, axisLine:{lineStyle:{color: palette.subtext}} },
-      visualMap: { min: 0, max: vmax, calculable: true, orient:"horizontal", left:"center", textStyle:{color: palette.text} },
+      visualMap: { min: 0, max: vmax, calculable: true, orient:"horizontal", left:"center", textStyle:{color: palette.text}, inRange:{color:[palette.series[0], palette.series[1], palette.series[5]]} },
       series: [{
         type: "heatmap",
         data,


### PR DESCRIPTION
## Summary
- add palette-driven gradient colors to the daily rhythm heatmap

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689653f10954832590fc22cbbdfc98fd