### PR TITLE
feat: report reply times in minutes

### DIFF
--- a/api/kpis.py
+++ b/api/kpis.py
@@ -133,7 +133,9 @@ def compute(df: pd.DataFrame) -> Dict[str, Any]:
     reply_simple = []
     for p in parts:
         v = pairs[pairs["to"] == p]["dt_sec"]
-        reply_simple.append({"person": p, "median": float(v.median()) if len(v)>0 else 0.0, "mean": float(v.mean()) if len(v)>0 else 0.0})
+        reply_simple.append({"person": p,
+                             "median": (float(v.median())/60) if len(v)>0 else 0.0,
+                             "mean": (float(v.mean())/60) if len(v)>0 else 0.0})
 
     q = df[~df["is_system"] & df["text"].str.contains(r"\?\s*$", regex=True)]
     unanswered_total = 0

--- a/services/api/kpis.py
+++ b/services/api/kpis.py
@@ -127,8 +127,8 @@ def compute(df: pd.DataFrame) -> Dict[str, Any]:
             arr = arr.clip(lower=0)
             reply_simple.append({
                 "person": str(person),
-                "median": float(arr.median()),
-                "mean": float(arr.mean()),
+                "median": float(arr.median()) / 60,
+                "mean": float(arr.mean()) / 60,
                 "n": int(arr.size),
             })
     # ensure all participants present

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -134,7 +134,7 @@ export default function Home() {
       tooltip: {},
       legend: { data: participants, textStyle:{color: palette.text} },
       xAxis: { type: "category", data: metrics, axisLabel:{color: palette.text}, axisLine:{lineStyle:{color: palette.subtext}} },
-      yAxis: { type: "value", name: "seconds", axisLabel:{color: palette.text}, axisLine:{lineStyle:{color: palette.subtext}} },
+      yAxis: { type: "value", name: "minutes", axisLabel:{color: palette.text}, axisLine:{lineStyle:{color: palette.subtext}} },
       series: participants.map(p => {
         const row = rs.find((r:any)=>r.person===p) || {};
         return {
@@ -275,7 +275,7 @@ export default function Home() {
             </div>
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              <Card title="Time to reply (seconds) — median & mean">
+              <Card title="Time to reply (minutes) — median & mean">
                 <Chart option={replyOption()} />
                 {(!kpis?.reply_simple || kpis.reply_simple.length===0) && <div className="text-sm text-gray-400 mt-2">No alternating replies detected yet.</div>}
               </Card>


### PR DESCRIPTION
## Summary
- convert reply time statistics from seconds to minutes in API
- update frontend chart to label reply times in minutes

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test" from package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689653bb684c8325a93e9c2fc0cc7897