### PR TITLE
feat: add side-by-side word cloud visualization

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -8,19 +8,20 @@
     "postinstall": "next telemetry disable || true"
   },
   "dependencies": {
-    "next": "14.2.5",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
+    "classnames": "2.5.1",
     "echarts": "5.5.0",
     "echarts-for-react": "3.0.2",
-    "classnames": "2.5.1"
+    "echarts-wordcloud": "^2.1.0",
+    "next": "14.2.5",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
   },
   "devDependencies": {
+    "@types/node": "20.12.7",
+    "@types/react": "18.2.66",
     "autoprefixer": "10.4.17",
     "postcss": "8.4.35",
     "tailwindcss": "3.4.3",
-    "typescript": "5.5.3",
-    "@types/react": "18.2.66",
-    "@types/node": "20.12.7"
+    "typescript": "5.5.3"
   }
 }

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from "react";
 import { getKPIs, loadSample, uploadFile } from "@/lib/api";
 import Card from "@/components/Card";
 import Chart from "@/components/Chart";
+import 'echarts-wordcloud';
 
 type KPI = any;
 
@@ -60,6 +61,8 @@ export default function Home() {
     });
     return map;
   }, [participants]);
+
+  const wordCloudParticipants = participants.slice(0, 2);
 
   const dateFilter = (day: string) => {
     if (startDate && day < startDate) return false;
@@ -199,6 +202,22 @@ export default function Home() {
     };
   };
 
+  const wordCloudOption = (person: string) => {
+    const data = (kpis?.word_cloud?.[person] || []) as Array<{name:string; value:number}>;
+    return {
+      backgroundColor: "transparent",
+      tooltip: {},
+      series: [{
+        type: 'wordCloud',
+        gridSize: 8,
+        sizeRange: [12, 50],
+        rotationRange: [0, 0],
+        textStyle: { color: colorMap[person] },
+        data
+      }]
+    };
+  };
+
   const affSplit = (kpis?.affection_split ?? []) as Array<{sender:string; affection:number}>;
   const qSplit = (kpis?.questions_split ?? []) as Array<{sender:string; questions:number; unanswered_15m:number}>;
   const bySender = (kpis?.by_sender ?? []) as Array<{sender:string; media:number}>;
@@ -298,6 +317,23 @@ export default function Home() {
                   ))}
                 </div>
                 <Chart option={heatOption()} height={320} />
+              </Card>
+            </div>
+
+            <div className="grid grid-cols-1 gap-6">
+              <Card title="Word cloud by participant">
+                {wordCloudParticipants.length === 2 ? (
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    {wordCloudParticipants.map(p => (
+                      <div key={p}>
+                        <div className="text-center mb-1 font-semibold">{p}</div>
+                        <Chart option={wordCloudOption(p)} height={260} />
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="text-sm text-gray-400">Need two participants for word clouds.</div>
+                )}
               </Card>
             </div>
 


### PR DESCRIPTION
## Summary
- compute word frequency for each participant and expose in KPIs
- show side-by-side word cloud charts for the first two participants
- add echarts-wordcloud dependency to render word clouds

## Testing
- `pytest`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68965465e2b88325b22d061bd79b326a