### PR TITLE
feat: dynamic timeline trendline and aggregation

### DIFF
--- a/web/components/Chart.tsx
+++ b/web/components/Chart.tsx
@@ -1,10 +1,10 @@
 import dynamic from "next/dynamic";
 const ReactECharts = dynamic(() => import("echarts-for-react"), { ssr: false });
 
-export default function Chart({ option, height=260 }: { option: any; height?: number }) {
+export default function Chart({ option, height=260, onEvents }: { option: any; height?: number; onEvents?: any }) {
   return (
     <div className="w-full">
-      <ReactECharts option={option} style={{ height }} notMerge={true} lazyUpdate={true} />
+      <ReactECharts option={option} style={{ height }} notMerge={true} lazyUpdate={true} onEvents={onEvents} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- recalculate timeline trendline based on zoomed range
- automatically aggregate timeline data by week when many days are shown
- expose chart events for zoom handling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module 'echarts-wordcloud/src/wordCloud')*

------
https://chatgpt.com/codex/tasks/task_e_689657b3207483259821ce181cbba731