### PR TITLE
fix: load echarts-wordcloud on client

### DIFF
--- a/web/components/Chart.tsx
+++ b/web/components/Chart.tsx
@@ -1,5 +1,12 @@
 import dynamic from "next/dynamic";
-const ReactECharts = dynamic(() => import("echarts-for-react"), { ssr: false });
+
+// Load the wordcloud extension on the client before initializing ECharts.
+const ReactECharts = dynamic(async () => {
+  if (typeof window !== "undefined") {
+    await import("echarts-wordcloud/dist/echarts-wordcloud.js");
+  }
+  return import("echarts-for-react");
+}, { ssr: false });
 
 export default function Chart({ option, height=260 }: { option: any; height?: number }) {
   return (

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -3,7 +3,6 @@ import { useEffect, useMemo, useState } from "react";
 import { getKPIs, loadSample, uploadFile } from "@/lib/api";
 import Card from "@/components/Card";
 import Chart from "@/components/Chart";
-import 'echarts-wordcloud';
 
 type KPI = any;
 


### PR DESCRIPTION
## Summary
- load echarts-wordcloud dynamically only on the client to avoid ESM resolution issues
- remove server-side wordcloud import from the index page

## Testing
- `cd web && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896588b53a083259bfbb30fd70826ce