### PR TITLE
Simplify reply time metric to average seconds

### DIFF
--- a/api/kpis.py
+++ b/api/kpis.py
@@ -133,7 +133,7 @@ def compute(df: pd.DataFrame) -> Dict[str, Any]:
     reply_simple = []
     for p in parts:
         v = pairs[pairs["to"] == p]["dt_sec"]
-        reply_simple.append({"person": p, "median": float(v.median()) if len(v)>0 else 0.0, "mean": float(v.mean()) if len(v)>0 else 0.0})
+        reply_simple.append({"person": p, "seconds": float(v.mean()) if len(v)>0 else 0.0})
 
     q = df[~df["is_system"] & df["text"].str.contains(r"\?\s*$", regex=True)]
     unanswered_total = 0

--- a/services/api/kpis.py
+++ b/services/api/kpis.py
@@ -1,5 +1,5 @@
 from typing import List, Dict, Any
-import re, numpy as np, pandas as pd
+import re, pandas as pd
 from collections import Counter
 from parse import Message
 
@@ -144,15 +144,14 @@ def compute(df: pd.DataFrame) -> Dict[str, Any]:
             arr = arr.clip(lower=0)
             reply_simple.append({
                 "person": str(person),
-                "median": float(arr.median()),
-                "mean": float(arr.mean()),
+                "seconds": float(arr.mean()),
                 "n": int(arr.size),
             })
     # ensure all participants present
     present = {r["person"] for r in reply_simple}
     for p in participants:
         if str(p) not in present:
-            reply_simple.append({"person": str(p), "median": 0.0, "mean": 0.0, "n": 0})
+            reply_simple.append({"person": str(p), "seconds": 0.0, "n": 0})
 
     # Interruptions
     runs_df = interruptions(d)
@@ -221,5 +220,5 @@ def compute(df: pd.DataFrame) -> Dict[str, Any]:
     }
     # legacy mirrors for compatibility
     payload["timeline"] = payload["timeline_messages"]
-    payload["reply_times_summary"] = [{"to": r["person"], "median": r["median"], "mean": r["mean"], "count": r["n"]} for r in reply_simple]
+    payload["reply_times_summary"] = [{"to": r["person"], "seconds": r["seconds"], "count": r["n"]} for r in reply_simple]
     return payload

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -149,23 +149,22 @@ export default function Home() {
 
   const replyOption = () => {
     const rs = (kpis?.reply_simple || []) as Array<any>;
-    const metrics = ["median", "mean"];
     return {
       backgroundColor: "transparent",
       textStyle: { color: palette.text },
       tooltip: { valueFormatter: (value: number) => formatNumber(value) },
-      legend: { data: participants, textStyle:{color: palette.text} },
-      xAxis: { type: "category", data: metrics, axisLabel:{color: palette.text}, axisLine:{lineStyle:{color: palette.subtext}} },
+      xAxis: { type: "category", data: participants, axisLabel:{color: palette.text}, axisLine:{lineStyle:{color: palette.subtext}} },
       yAxis: { type: "value", name: "seconds", axisLabel:{color: palette.text, formatter: (value:number) => formatNumber(value)}, axisLine:{lineStyle:{color: palette.subtext}} },
-      series: participants.map(p => {
-        const row = rs.find((r:any)=>r.person===p) || {};
-        return {
-          name: p,
+      series: [
+        {
           type: "bar",
-          data: metrics.map(m => m === "median" ? (row.median || 0) : (row.mean || 0)),
-          itemStyle: { color: colorMap[p] }
-        };
-      })
+          data: participants.map(p => {
+            const row = rs.find((r:any)=>r.person===p) || {};
+            return { value: row.seconds || 0, itemStyle: { color: colorMap[p] } };
+          }),
+          barWidth: "40%"
+        }
+      ]
     };
   };
 
@@ -384,7 +383,7 @@ export default function Home() {
             </div>
 
             <div className="grid grid-cols-1 gap-6">
-              <Card title="Time to reply (seconds) — median & mean">
+              <Card title="Seconds to reply">
                 <Chart option={replyOption()} />
                 {(!kpis?.reply_simple || kpis.reply_simple.length===0) && <div className="text-sm text-gray-400 mt-2">No alternating replies detected yet.</div>}
               </Card>


### PR DESCRIPTION
## Summary
- drop median reply calculations in the API and expose only average seconds to reply
- update dashboard to chart a single "seconds to reply" bar per participant
- remove unused numpy import

## Testing
- `pytest`
- `(cd web && npm test)` *(fails: Missing script: "test")*
- `(cd web && npm run build)`

------
https://chatgpt.com/codex/tasks/task_e_68965b17f0648325830cd10c71d42898