### PR TITLE
Fix trendline disappearing after graph filter

### DIFF
--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -400,7 +400,7 @@ export default function Home() {
                     Trend
                   </label>
                 </div>
-                <Chart option={timelineOption()} height={280} onEvents={{ dataZoom: handleZoom }} />
+                <Chart option={timelineOption()} height={280} onEvents={{ datazoom: handleZoom }} />
                 {(!kpis || (kpis[timelineMetric==="messages"?"timeline_messages":"timeline_words"]||[]).length===0) && <div className="text-sm text-gray-400 mt-2">No timeline data yet.</div>}
               </Card>
             </div>


### PR DESCRIPTION
## Summary
- Fix timeline chart to recalculate trendline when using built-in data zoom

## Testing
- `npm test` (fails: Missing script)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68965b78f1348325a330fe59541025c2