### PR TITLE
Fix word cloud rendering

### DIFF
--- a/web/components/Chart.tsx
+++ b/web/components/Chart.tsx
@@ -3,7 +3,7 @@ import dynamic from "next/dynamic";
 // Load the wordcloud extension on the client before initializing ECharts.
 const ReactECharts = dynamic(async () => {
   if (typeof window !== "undefined") {
-    await import("echarts-wordcloud/dist/echarts-wordcloud.js");
+    await import("echarts-wordcloud");
   }
   return import("echarts-for-react");
 }, { ssr: false });


### PR DESCRIPTION
## Summary
- Correctly import the ECharts word cloud extension so charts display words

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68965afce9d08325abe3464ee0c2fb0a