### PR TITLE
Filter media messages and expand stopwords for word clouds

### DIFF
--- a/services/api/requirements.txt
+++ b/services/api/requirements.txt
@@ -6,3 +6,4 @@ numpy==1.26.4
 pandas==2.2.2
 
 python-multipart==0.0.9
+wordcloud==1.9.4


### PR DESCRIPTION
## Summary
- use wordcloud's stopword list to drop common filler words like "I'm" and "or"
- skip messages with `<media omitted>` when computing word clouds
- add `wordcloud` dependency for stopword support

## Testing
- `pytest`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68965df54ab483259985ecc66508b67b