### PR TITLE
Enable emoji support in wordcloud

### DIFF
--- a/services/api/kpis.py
+++ b/services/api/kpis.py
@@ -3,6 +3,7 @@ import re, pandas as pd
 from collections import Counter
 from wordcloud import STOPWORDS as WC_STOPWORDS
 from parse import Message
+import emoji
 
 AFFECTION_TOKENS = [
     "love you","luv u","miss you","😘","❤️","❤","💕","💖",
@@ -28,7 +29,9 @@ def word_counts(df: pd.DataFrame, participants: List[str], top_n: int = 50) -> D
         words: List[str] = []
         for text in sub["text"].fillna(""):
             tokens = re.findall(r"[A-Za-z']+", text.lower())
+            emoji_tokens = [d["emoji"] for d in emoji.emoji_list(text)]
             words.extend([w for w in tokens if w not in STOPWORDS])
+            words.extend(emoji_tokens)
         cnt = Counter(words)
         out[str(sender)] = [{"name": w, "value": int(c)} for w, c in cnt.most_common(top_n)]
     return out

--- a/services/api/requirements.txt
+++ b/services/api/requirements.txt
@@ -7,3 +7,4 @@ pandas==2.2.2
 
 python-multipart==0.0.9
 wordcloud==1.9.4
+emoji==2.11.1

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -301,7 +301,10 @@ export default function Home() {
         gridSize: 8,
         sizeRange: [12, 50],
         rotationRange: [0, 0],
-        textStyle: { color: colorMap[person] },
+        textStyle: {
+          color: colorMap[person],
+          fontFamily: "'Segoe UI Emoji','Apple Color Emoji','Noto Color Emoji','Android Emoji','EmojiSymbols','EmojiOne','Twemoji','sans-serif'"
+        },
         data
       }]
     };


### PR DESCRIPTION
## Summary
- include emoji parsing in backend word counts
- allow wordcloud to render emojis using emoji-capable fonts
- add emoji dependency to API requirements

## Testing
- `pytest`
- `cd web && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6896665a83a88325af050a1c3dd53af2