### PR TITLE
Add word categories and filtering to word cloud

### DIFF
--- a/services/api/kpis.py
+++ b/services/api/kpis.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Set
 import re, pandas as pd
 from collections import Counter
 from wordcloud import STOPWORDS as WC_STOPWORDS
@@ -10,6 +10,7 @@ AFFECTION_TOKENS = [
     "babe","baby","hun","honey","cutie","sweetheart","proud of you"
 ]
 PROFANITY = ["fuck","shit","bitch","asshole","dick","cuck"]
+SEXUAL_WORDS = ["sex","sexy","naked","nude","dick","pussy","boobs","tits","cock","cum","horny"]
 PRONOUNS_WE = ["we","us","our","ours"]
 PRONOUNS_I = ["i","me","my","mine"]
 QUESTION_PAT = re.compile(r"\?\s*$|^\s*(?:who|what|when|where|why|how|can|do|did|are|is|should)\b", re.IGNORECASE)
@@ -18,8 +19,8 @@ QUESTION_PAT = re.compile(r"\?\s*$|^\s*(?:who|what|when|where|why|how|can|do|did
 STOPWORDS = set(WC_STOPWORDS)
 STOPWORDS.update({"im", "us", "our", "ours", "your"})
 
-def word_counts(df: pd.DataFrame, participants: List[str], top_n: int = 50) -> Dict[str, List[Dict[str, int]]]:
-    out: Dict[str, List[Dict[str, int]]] = {}
+def word_counts(df: pd.DataFrame, participants: List[str], top_n: int = 50) -> Dict[str, List[Dict[str, Any]]]:
+    out: Dict[str, List[Dict[str, Any]]] = {}
     filtered = df[
         df["sender"].isin(participants)
         & (~df["has_media"])
@@ -27,13 +28,30 @@ def word_counts(df: pd.DataFrame, participants: List[str], top_n: int = 50) -> D
     ]
     for sender, sub in filtered.groupby("sender"):
         words: List[str] = []
+        tags: Dict[str, Set[str]] = {}
         for text in sub["text"].fillna(""):
             tokens = re.findall(r"[A-Za-z']+", text.lower())
             emoji_tokens = [d["emoji"] for d in emoji.emoji_list(text)]
-            words.extend([w for w in tokens if w not in STOPWORDS])
-            words.extend(emoji_tokens)
+            for w in tokens:
+                if w in STOPWORDS:
+                    continue
+                words.append(w)
+                if w not in tags:
+                    tags[w] = set()
+                if w in PROFANITY:
+                    tags[w].add("swear")
+                if w in SEXUAL_WORDS:
+                    tags[w].add("sexual")
+            for e in emoji_tokens:
+                words.append(e)
+                if e not in tags:
+                    tags[e] = set()
+                tags[e].add("emoji")
         cnt = Counter(words)
-        out[str(sender)] = [{"name": w, "value": int(c)} for w, c in cnt.most_common(top_n)]
+        out[str(sender)] = [
+            {"name": w, "value": int(c), "tags": sorted(list(tags.get(w, set())))}
+            for w, c in cnt.most_common(top_n)
+        ]
     return out
 
 def to_df(messages: List[Message]) -> pd.DataFrame:

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -69,6 +69,8 @@ export default function Home() {
   }, [participants]);
 
   const wordCloudParticipants = participants.slice(0, 2);
+  const wordCategories = ["emoji", "swear", "sexual"];
+  const [wordFilters, setWordFilters] = useState<string[]>([]);
 
   const dateFilter = (day: string) => {
     if (startDate && day < startDate) return false;
@@ -292,7 +294,10 @@ export default function Home() {
   };
 
   const wordCloudOption = (person: string) => {
-    const data = (kpis?.word_cloud?.[person] || []) as Array<{name:string; value:number}>;
+    const raw = (kpis?.word_cloud?.[person] || []) as Array<{name:string; value:number; tags?:string[]}>;
+    const data = wordFilters.length
+      ? raw.filter(r => (r.tags || []).some(t => wordFilters.includes(t)))
+      : raw;
     return {
       backgroundColor: "transparent",
       tooltip: {},
@@ -421,6 +426,24 @@ export default function Home() {
 
             <div className="grid grid-cols-1 gap-6">
               <Card title="Word cloud by participant">
+                <div className="mb-2 flex flex-wrap gap-3">
+                  {wordCategories.map(cat => (
+                    <label key={cat} className="text-xs flex items-center gap-1">
+                      <input
+                        type="checkbox"
+                        checked={wordFilters.includes(cat)}
+                        onChange={() =>
+                          setWordFilters(prev =>
+                            prev.includes(cat)
+                              ? prev.filter(c => c !== cat)
+                              : [...prev, cat]
+                          )
+                        }
+                      />
+                      {cat}
+                    </label>
+                  ))}
+                </div>
                 {wordCloudParticipants.length === 2 ? (
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                     {wordCloudParticipants.map(p => (


### PR DESCRIPTION
## Summary
- tag words with emoji, swear, and sexual categories in KPI generation
- add UI to filter word clouds by selected categories

## Testing
- `npm test` (fails: Missing script)
- `pytest`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689669e3a8488325a706d72625270d9a