### PR TITLE
Expand word cloud dictionaries and add space category

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Two services:
 - **api**: FastAPI with parser and KPI engine
 - **web**: Next.js dashboard with Tailwind and shadcn/ui using Apache ECharts
 
+Word clouds categorize terms, highlighting emoji, swear, sexual, and space-themed words.
+
 ## Run
 ```bash
 docker compose up --build

--- a/services/api/kpis.py
+++ b/services/api/kpis.py
@@ -9,8 +9,18 @@ AFFECTION_TOKENS = [
     "love you","luv u","miss you","😘","❤️","❤","💕","💖",
     "babe","baby","hun","honey","cutie","sweetheart","proud of you"
 ]
-PROFANITY = ["fuck","shit","bitch","asshole","dick","cuck"]
-SEXUAL_WORDS = ["sex","sexy","naked","nude","dick","pussy","boobs","tits","cock","cum","horny"]
+PROFANITY = [
+    "fuck","shit","bitch","ass","asshole","dick","cuck","bastard",
+    "damn","crap","hell","piss","motherfucker","bullshit"
+]
+SEXUAL_WORDS = [
+    "sex","sexy","naked","nude","dick","pussy","boobs","tits","cock","cum",
+    "horny","ass","booty","butt","lingerie","thighs","kinky","seduce"
+]
+SPACE_WORDS = [
+    "space","rocket","planet","star","galaxy","universe","moon",
+    "mars","astronaut","cosmos","nebula","nasa"
+]
 PRONOUNS_WE = ["we","us","our","ours"]
 PRONOUNS_I = ["i","me","my","mine"]
 QUESTION_PAT = re.compile(r"\?\s*$|^\s*(?:who|what|when|where|why|how|can|do|did|are|is|should)\b", re.IGNORECASE)
@@ -42,6 +52,8 @@ def word_counts(df: pd.DataFrame, participants: List[str], top_n: int = 50) -> D
                     tags[w].add("swear")
                 if w in SEXUAL_WORDS:
                     tags[w].add("sexual")
+                if w in SPACE_WORDS:
+                    tags[w].add("space")
             for e in emoji_tokens:
                 words.append(e)
                 if e not in tags:

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -69,7 +69,7 @@ export default function Home() {
   }, [participants]);
 
   const wordCloudParticipants = participants.slice(0, 2);
-  const wordCategories = ["emoji", "swear", "sexual"];
+  const wordCategories = ["emoji", "swear", "sexual", "space"];
   const [wordFilters, setWordFilters] = useState<string[]>([]);
 
   const dateFilter = (day: string) => {


### PR DESCRIPTION
## Summary
- broaden profanity and sexual word lists for richer tagging
- introduce space-themed word category and surface it in the UI
- document word cloud categories in README

## Testing
- `python -m py_compile services/api/kpis.py`
- `pytest -q`
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68967c6cc58083258a5756cea4771e8e