### PR TITLE
Revamp dashboard layout and styling

### DIFF
--- a/web/components/Card.tsx
+++ b/web/components/Card.tsx
@@ -2,8 +2,11 @@ import { ReactNode } from "react";
 
 export default function Card({ title, children, tooltip }: { title: string; children: ReactNode; tooltip?: string }) {
   return (
-    <div className="rounded-2xl bg-white/5 backdrop-blur border border-white/10 p-4 shadow-sm" title={tooltip}>
-      <div className="text-sm text-gray-300 mb-2">{title}</div>
+    <div
+      className="rounded-xl bg-white/5 border border-white/10 p-6 shadow-md backdrop-blur"
+      title={tooltip}
+    >
+      <h2 className="text-sm font-semibold text-gray-200 mb-4">{title}</h2>
       <div>{children}</div>
     </div>
   );

--- a/web/components/Layout.tsx
+++ b/web/components/Layout.tsx
@@ -1,0 +1,22 @@
+import Head from "next/head";
+import { ReactNode } from "react";
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <Head>
+        <title>WhatsApp Relationship Analytics</title>
+      </Head>
+      <div className="min-h-screen bg-gradient-to-br from-gray-900 via-violet-900 to-slate-900 text-gray-50">
+        <header className="border-b border-white/10 bg-white/5 backdrop-blur">
+          <div className="max-w-7xl mx-auto px-6 py-4">
+            <h1 className="text-2xl font-semibold">WhatsApp Relationship Analytics</h1>
+          </div>
+        </header>
+        <main className="max-w-7xl mx-auto p-6 space-y-6">
+          {children}
+        </main>
+      </div>
+    </>
+  );
+}

--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -1,6 +1,11 @@
 import "@/styles/globals.css";
 import type { AppProps } from "next/app";
+import Layout from "@/components/Layout";
 
 export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  return (
+    <Layout>
+      <Component {...pageProps} />
+    </Layout>
+  );
 }

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -7,11 +7,10 @@ import Chart from "@/components/Chart";
 type KPI = any;
 
 const palette = {
-  bg: "radial-gradient(1200px 600px at 20% 10%, rgba(143,76,255,0.25), transparent 60%), radial-gradient(1000px 600px at 80% 20%, rgba(0,184,255,0.18), transparent 60%), radial-gradient(1000px 600px at 50% 80%, rgba(255,80,150,0.18), transparent 60%), #0b0f17",
-  text: "#e6e8ef",
-  subtext: "#9aa4b2",
-  surfaces: "#0f1521",
-  series: ["#a78bfa", "#22d3ee", "#f59e0b", "#ef4444", "#10b981", "#f472b6"]
+  text: "#e2e8f0",
+  subtext: "#94a3b8",
+  surfaces: "#1e293b",
+  series: ["#7dd3fc", "#c4b5fd", "#f9a8d4", "#fdba74", "#fca5a5", "#bef264"]
 };
 const formatNumber = (n: number) => n.toLocaleString();
 
@@ -389,21 +388,19 @@ async function fetchConflicts() {
   };
 
   return (
-    <div style={{ background: palette.bg }} className="min-h-screen text-white">
-      <div className="max-w-7xl mx-auto p-6 space-y-6">
-        <div className="flex items-center justify-between">
-          <h1 className="text-2xl font-semibold">WhatsApp Relationship Analytics - v0.2.9</h1>
-          <label className="px-4 py-2 rounded-xl bg-white/10 hover:bg-white/20 transition cursor-pointer">
-            {busy ? "Uploading..." : "Upload .txt"}
-            <input type="file" className="hidden" accept=".txt" onChange={(e)=>e.target.files&&onUpload(e.target.files[0])} />
-          </label>
-        </div>
-        {err && <div className="text-red-400">{err}</div>}
-        {conflictErr && <div className="text-red-400">{conflictErr}</div>}
-        {!kpis && <div className="text-gray-300">Load sample or upload a WhatsApp export.</div>}
-        {kpis && (
-          <>
-            <div className="flex flex-col md:flex-row gap-2 md:items-end">
+    <>
+      <div className="flex items-center justify-end">
+        <label className="px-4 py-2 rounded-xl bg-white/10 hover:bg-white/20 transition cursor-pointer">
+          {busy ? "Uploading..." : "Upload chat"}
+          <input type="file" className="hidden" accept=".txt" onChange={(e)=>e.target.files&&onUpload(e.target.files[0])} />
+        </label>
+      </div>
+      {err && <div className="text-red-400">{err}</div>}
+      {conflictErr && <div className="text-red-400">{conflictErr}</div>}
+      {!kpis && <div className="text-gray-300">Load sample or upload a WhatsApp export.</div>}
+      {kpis && (
+        <>
+          <div className="flex flex-col md:flex-row gap-2 md:items-end">
               <div>
                 <label className="text-sm mr-2">Start</label>
                 <input type="date" value={startDate} onChange={e=>setStartDate(e.target.value)} className="bg-white/10 rounded px-2 py-1" />
@@ -567,7 +564,6 @@ async function fetchConflicts() {
           </>
         )}
         <div className="text-xs text-gray-400">v0.2.9 — visual refinements • API v{apiVersion}</div>
-      </div>
-    </div>
+    </>
   );
 }

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -1,4 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-body { @apply text-white; }
+
+body {
+  @apply text-gray-50 font-sans;
+}


### PR DESCRIPTION
## Summary
- introduce global Layout with gradient background and header
- refresh Card component styling for a cleaner look
- streamline dashboard page with new color palette and upload action

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68976f412f3883258097869a7f5cf318