### PR TITLE
Fix conflict month grouping and ordering

### DIFF
--- a/services/api/conflict.py
+++ b/services/api/conflict.py
@@ -137,14 +137,19 @@ def periods_to_months(periods: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Aggregate two-week period results into calendar months."""
     months: Dict[str, Dict[str, Any]] = {}
     for p in periods:
-        start = pd.Period(p["period"], freq="2W").start_time
-        month_key = f"{start:%Y-%m}"
-        month_entry = months.setdefault(
-            month_key, {"month": month_key, "total_conflicts": 0, "conflicts": []}
-        )
         for c in p.get("conflicts", []):
+            try:
+                dt = pd.to_datetime(c.get("date"))
+            except Exception:
+                continue
+            month_key = dt.strftime("%Y-%m")
+            month_entry = months.setdefault(
+                month_key, {"month": month_key, "total_conflicts": 0, "conflicts": []}
+            )
             month_entry["conflicts"].append(c)
             month_entry["total_conflicts"] += 1
+    for m in months.values():
+        m["conflicts"].sort(key=lambda x: x.get("date", ""))
     # Ensure months are returned in chronological order
     return [months[m] for m in sorted(months)]
 

--- a/services/api/test_periods_to_months.py
+++ b/services/api/test_periods_to_months.py
@@ -1,0 +1,25 @@
+import pytest
+
+from services.api.conflict import periods_to_months
+
+def test_periods_to_months_groups_by_conflict_date_and_sorts():
+    periods = [
+        {
+            "period": "2024-01-15/2024-01-28",
+            "conflicts": [
+                {"date": "2024-02-05", "summary": "later"},
+                {"date": "2024-02-01", "summary": "earlier"},
+            ],
+        },
+        {
+            "period": "2024-01-29/2024-02-11",
+            "conflicts": [
+                {"date": "2024-01-30", "summary": "jan"},
+            ],
+        },
+    ]
+    months = periods_to_months(periods)
+    assert [m["month"] for m in months] == ["2024-01", "2024-02"]
+    assert [c["date"] for c in months[0]["conflicts"]] == ["2024-01-30"]
+    assert [c["date"] for c in months[1]["conflicts"]] == ["2024-02-01", "2024-02-05"]
+    assert [m["total_conflicts"] for m in months] == [1, 2]

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -26,15 +26,17 @@ export async function getConflicts(
     const aggregate = (per: any[]) => {
       const months: Record<string, {month: string; total_conflicts: number; conflicts: any[]}> = {};
       for (const p of per) {
-        const start = new Date(p.period.split("/")[0]);
-        const monthKey = start.toISOString().slice(0,7);
-        if (!months[monthKey]) {
-          months[monthKey] = {month: monthKey, total_conflicts: 0, conflicts: []};
-        }
         for (const c of (p.conflicts || [])) {
+          const monthKey = new Date(c.date).toISOString().slice(0,7);
+          if (!months[monthKey]) {
+            months[monthKey] = {month: monthKey, total_conflicts: 0, conflicts: []};
+          }
           months[monthKey].conflicts.push(c);
           months[monthKey].total_conflicts += 1;
         }
+      }
+      for (const m of Object.values(months)) {
+        m.conflicts.sort((a,b)=>a.date.localeCompare(b.date));
       }
       return Object.values(months).sort((a,b)=>a.month.localeCompare(b.month));
     };


### PR DESCRIPTION
## Summary
- group conflicts by each conflict's date instead of period start
- sort conflicts within months and months chronologically
- add regression test for periods_to_months logic

## Testing
- `pytest -q`
- `npm --prefix web test` *(fails: Missing script: "test")*
- `npm --prefix web run build`


------
https://chatgpt.com/codex/tasks/task_e_6897a1a63a8483258d2bb64b098bc068