### PR TITLE
Fix duplicate ReactNode import causing Next.js build error

### DIFF
--- a/web/components/Layout.tsx
+++ b/web/components/Layout.tsx
@@ -2,8 +2,6 @@ import Head from "next/head";
 
 import { ReactNode, useEffect, useState } from "react";
 import { MONKEYTYPE_THEMES } from "@/lib/monkeytypeThemes";
-import { ReactNode } from "react";
-import Sidebar from "@/components/Sidebar";
 
 
 export default function Layout({ children }: { children: ReactNode }) {


### PR DESCRIPTION
## Summary
- remove redundant ReactNode and Sidebar imports from Layout component

## Testing
- `cd web && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6897a5ce70e083259edbd934122bac15