### PR TITLE
feat: add animated smoke background

### DIFF
--- a/web/components/Layout.tsx
+++ b/web/components/Layout.tsx
@@ -36,7 +36,7 @@ export default function Layout({ children }: { children: ReactNode }) {
       </Head>
       <div className="min-h-screen relative" style={{ backgroundColor: "var(--bg-color)", color: "var(--text-color)" }}>
         <div
-          className="pointer-events-none fixed inset-0 bg-center bg-cover bg-fixed -z-10"
+          className="pointer-events-none fixed inset-0 bg-center bg-cover bg-fixed -z-10 smoke-animation"
           style={{
             backgroundImage: "url('/smoke.svg')",
             backgroundColor: "var(--main-color)",

--- a/web/public/smoke.svg
+++ b/web/public/smoke.svg
@@ -1,6 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="400" height="400">
   <filter id="s">
-    <feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="5" />
+    <feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="5" seed="2">
+      <animate attributeName="baseFrequency" dur="60s" values="0.9;0.8;0.9" repeatCount="indefinite" />
+    </feTurbulence>
     <feColorMatrix type="saturate" values="0" />
     <feComponentTransfer>
       <feFuncA type="linear" slope="0.3" />

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -7,3 +7,17 @@ body {
   color: var(--text-color);
   background-color: var(--bg-color);
 }
+
+@keyframes smoke {
+  from {
+    background-position: 0 0;
+  }
+  to {
+    background-position: 200% 200%;
+  }
+}
+
+.smoke-animation {
+  background-size: 200% 200%;
+  animation: smoke 60s linear infinite;
+}


### PR DESCRIPTION
## Summary
- animate SVG smoke background
- add CSS animation to slowly move background
- hook up smoke animation in main layout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897ac247b1c8325aa9b2abf1f54e08b