### PR TITLE
Fix smokey background overlay visibility

### DIFF
--- a/web/components/Layout.tsx
+++ b/web/components/Layout.tsx
@@ -36,7 +36,7 @@ export default function Layout({ children }: { children: ReactNode }) {
       </Head>
       <div className="min-h-screen relative" style={{ backgroundColor: "var(--bg-color)", color: "var(--text-color)" }}>
         <div
-          className="pointer-events-none fixed inset-0 -z-10"
+          className="pointer-events-none fixed inset-0 z-0"
           style={{
             backgroundColor: "var(--main-color)",
             maskImage: "url('/smoke.svg')",
@@ -51,7 +51,7 @@ export default function Layout({ children }: { children: ReactNode }) {
           }}
         ></div>
         <header
-          className="border-b"
+          className="relative z-10 border-b"
           style={{ backgroundColor: "var(--sub-alt-color)", borderColor: "var(--sub-color)" }}
         >
           <div className="px-6 py-4 flex items-center justify-between">
@@ -76,7 +76,7 @@ export default function Layout({ children }: { children: ReactNode }) {
             </select>
           </div>
         </header>
-        <div className="flex">
+        <div className="flex relative z-10">
           <Sidebar />
           <main className="flex-1 p-6 space-y-6">
             {children}


### PR DESCRIPTION
## Summary
- ensure smokey background overlay renders above the page background and below content by adjusting z-index and layering

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898a38a01548325bcb32359c6a43a89