### PR TITLE
Fix smokey background overlay visibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ npm-debug.log*
 yarn.lock
 pnpm-lock.yaml
 
+# Web-specific artifacts
+web/package-lock.json
+web/cache/
+
 # Python
 __pycache__/
 *.pyc

--- a/web/components/Layout.tsx
+++ b/web/components/Layout.tsx
@@ -4,6 +4,7 @@ import { ReactNode, useEffect, useState } from "react";
 
 import { KEYCAP_THEME_NAMES, KEYCAP_THEMES } from "@/lib/keycapThemes";
 import Sidebar from "@/components/Sidebar";
+import SmokeyBackground from "@/components/SmokeyBackground";
 
 
 
@@ -35,23 +36,9 @@ export default function Layout({ children }: { children: ReactNode }) {
         <title>WhatsApp Relationship Analytics</title>
       </Head>
       <div className="min-h-screen relative" style={{ backgroundColor: "var(--bg-color)", color: "var(--text-color)" }}>
-        <div
-          className="pointer-events-none fixed inset-0 -z-10"
-          style={{
-            backgroundColor: "var(--main-color)",
-            maskImage: "url('/smoke.svg')",
-            WebkitMaskImage: "url('/smoke.svg')",
-            maskSize: "cover",
-            WebkitMaskSize: "cover",
-            maskRepeat: "no-repeat",
-            WebkitMaskRepeat: "no-repeat",
-            maskPosition: "center",
-            WebkitMaskPosition: "center",
-            opacity: 0.2,
-          }}
-        ></div>
+        <SmokeyBackground />
         <header
-          className="border-b"
+          className="relative z-10 border-b"
           style={{ backgroundColor: "var(--sub-alt-color)", borderColor: "var(--sub-color)" }}
         >
           <div className="px-6 py-4 flex items-center justify-between">
@@ -76,7 +63,7 @@ export default function Layout({ children }: { children: ReactNode }) {
             </select>
           </div>
         </header>
-        <div className="flex">
+        <div className="flex relative z-10">
           <Sidebar />
           <main className="flex-1 p-6 space-y-6">
             {children}

--- a/web/components/SmokeyBackground.tsx
+++ b/web/components/SmokeyBackground.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+export default function SmokeyBackground() {
+  return (
+    <svg
+      className="pointer-events-none fixed inset-0 z-0"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <filter id="smoke">
+        <feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="5" seed="2">
+          <animate attributeName="baseFrequency" dur="60s" values="0.9;0.8;0.9" repeatCount="indefinite" />
+        </feTurbulence>
+        <feColorMatrix type="saturate" values="0" />
+        <feComponentTransfer>
+          <feFuncA type="linear" slope="0.5" />
+        </feComponentTransfer>
+      </filter>
+      <rect width="100%" height="100%" filter="url(#smoke)" fill="var(--main-color)" opacity="0.2" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- render animated smokey SVG overlay with theme color using inline component
- ignore web-specific cache and lock files

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898a38a01548325bcb32359c6a43a89