### PR TITLE
feat: expand theme palettes

### DIFF
--- a/web/lib/useThemePalette.ts
+++ b/web/lib/useThemePalette.ts
@@ -1,11 +1,51 @@
 import { useEffect, useState } from "react";
-import { KEYCAP_THEMES, KEYCAP_THEME_NAMES } from "./keycapThemes";
+import { KEYCAP_THEMES, KEYCAP_THEME_NAMES, KeycapTheme } from "./keycapThemes";
 
 export interface Palette {
   text: string;
   subtext: string;
   surfaces: string;
   series: string[];
+}
+
+function clamp(value: number, min = 0, max = 255): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function hex(v: number): string {
+  const h = v.toString(16).toUpperCase();
+  return h.length === 1 ? `0${h}` : h;
+}
+
+function lighten(color: string, percent: number): string {
+  const num = parseInt(color.slice(1), 16);
+  let r = num >> 16;
+  let g = (num >> 8) & 0xff;
+  let b = num & 0xff;
+  r = clamp(Math.round(r + (255 - r) * (percent / 100)));
+  g = clamp(Math.round(g + (255 - g) * (percent / 100)));
+  b = clamp(Math.round(b + (255 - b) * (percent / 100)));
+  return `#${hex(r)}${hex(g)}${hex(b)}`;
+}
+
+function darken(color: string, percent: number): string {
+  const num = parseInt(color.slice(1), 16);
+  let r = num >> 16;
+  let g = (num >> 8) & 0xff;
+  let b = num & 0xff;
+  r = clamp(Math.round(r * (1 - percent / 100)));
+  g = clamp(Math.round(g * (1 - percent / 100)));
+  b = clamp(Math.round(b * (1 - percent / 100)));
+  return `#${hex(r)}${hex(g)}${hex(b)}`;
+}
+
+function extendSeries(theme: KeycapTheme): string[] {
+  const extra = [
+    lighten(theme.main, 20),
+    darken(theme.main, 20),
+    lighten(theme.surfaces, 20)
+  ];
+  return theme.series.concat(extra);
 }
 
 export default function useThemePalette(): Palette {
@@ -17,13 +57,13 @@ export default function useThemePalette(): Palette {
 
   const [palette, setPalette] = useState<Palette>(() => {
     const t = KEYCAP_THEMES[getTheme()];
-    return { text: t.text, subtext: t.subtext, surfaces: t.surfaces, series: t.series };
+    return { text: t.text, subtext: t.subtext, surfaces: t.surfaces, series: extendSeries(t) };
   });
 
   useEffect(() => {
     const update = () => {
       const t = KEYCAP_THEMES[getTheme()];
-      setPalette({ text: t.text, subtext: t.subtext, surfaces: t.surfaces, series: t.series });
+      setPalette({ text: t.text, subtext: t.subtext, surfaces: t.surfaces, series: extendSeries(t) });
     };
     update();
     window.addEventListener("themechange", update);


### PR DESCRIPTION
## Summary
- generate lighter and darker variations for each theme
- append these derived colors to the theme's chart palette

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898a41f40d48325a59438c4cd9685b3