### PR TITLE
fix: improve conflict chart colors

### DIFF
--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -357,7 +357,7 @@ async function fetchConflicts() {
       tooltip: { valueFormatter: (value: number) => formatNumber(value) },
       xAxis: { type: "category", data: months, axisLabel:{color: palette.text}, axisLine:{lineStyle:{color: palette.subtext}} },
       yAxis: { type: "value", axisLabel:{color: palette.text, formatter: (value:number) => formatNumber(value)}, axisLine:{lineStyle:{color: palette.subtext}} },
-      series: [{ type: "bar", data: totals, itemStyle:{ color: palette.series[3] }, barWidth: "60%" }],
+      series: [{ type: "bar", data: totals, itemStyle:{ color: palette.series[2] }, barWidth: "60%" }],
       grid: { left: 40, right: 20, top: 20, bottom: 60 }
     };
   };
@@ -379,7 +379,7 @@ async function fetchConflicts() {
       },
       xAxis: { type: "time", axisLabel:{color: palette.text}, axisLine:{lineStyle:{color: palette.subtext}} },
       yAxis: { show: false },
-      series: [{ type: "scatter", symbolSize:8, data: pts.map(p=>({ value:[p.date,1], date:p.date, summary:p.summary })), itemStyle:{ color: palette.series[3] } }]
+      series: [{ type: "scatter", symbolSize:8, data: pts.map(p=>({ value:[p.date,1], date:p.date, summary:p.summary })), itemStyle:{ color: palette.series[2] } }]
     };
   };
 


### PR DESCRIPTION
## Summary
- make conflict bar chart bars use palette accent color
- adjust conflict timeline points to accent color for better contrast

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a04fb61308325b90b5b861ad3f06a