### PR TITLE
feat: apply theme palette using tailwind variables

### DIFF
--- a/web/components/Card.tsx
+++ b/web/components/Card.tsx
@@ -3,11 +3,10 @@ import { ReactNode } from "react";
 export default function Card({ title, children, tooltip }: { title: string; children: ReactNode; tooltip?: string }) {
   return (
     <div
-      className="rounded-xl border p-6 shadow-md backdrop-blur"
+      className="rounded-xl border p-6 shadow-md backdrop-blur bg-sub-alt border-sub"
       title={tooltip}
-      style={{ backgroundColor: "var(--sub-alt-color)", borderColor: "var(--sub-color)" }}
     >
-      <h2 className="text-sm font-semibold mb-4" style={{ color: "var(--sub-color)" }}>
+      <h2 className="text-sm font-semibold mb-4 text-sub">
         {title}
       </h2>
       <div>{children}</div>

--- a/web/components/Layout.tsx
+++ b/web/components/Layout.tsx
@@ -35,27 +35,21 @@ export default function Layout({ children }: { children: ReactNode }) {
       <Head>
         <title>WhatsApp Relationship Analytics</title>
       </Head>
-      <div className="min-h-screen relative" style={{ backgroundColor: "var(--bg-color)", color: "var(--text-color)" }}>
+      <div className="min-h-screen relative bg-bg text-text">
 
         <SmokeyBackground />
 
         <header
-          className="relative z-10 border-b"
-          style={{ backgroundColor: "var(--sub-alt-color)", borderColor: "var(--sub-color)" }}
+          className="relative z-10 border-b bg-sub-alt border-sub"
         >
           <div className="px-6 py-4 flex items-center justify-between">
-            <h1 className="text-2xl font-semibold" style={{ color: "var(--main-color)" }}>
+            <h1 className="text-2xl font-semibold text-main">
               WhatsApp Relationship Analytics
             </h1>
             <select
               value={theme}
               onChange={(e) => setTheme(e.target.value)}
-              className="text-sm rounded px-2 py-1"
-              style={{
-                backgroundColor: "var(--sub-alt-color)",
-                color: "var(--text-color)",
-                border: "1px solid var(--sub-color)",
-              }}
+              className="text-sm rounded px-2 py-1 bg-sub-alt text-text border border-sub"
             >
               {KEYCAP_THEME_NAMES.map((t) => (
                 <option key={t} value={t}>

--- a/web/components/Sidebar.tsx
+++ b/web/components/Sidebar.tsx
@@ -10,11 +10,11 @@ const sections = [
 
 export default function Sidebar() {
   return (
-    <nav className="hidden md:block w-56 bg-white/5 border-r border-white/10 p-4">
+    <nav className="hidden md:block w-56 bg-sub-alt border-r border-sub p-4 text-text">
       <ul className="space-y-2 text-sm">
         {sections.map((s) => (
           <li key={s.id}>
-            <a href={`#${s.id}`} className="block px-3 py-2 rounded hover:bg-white/10">
+            <a href={`#${s.id}`} className="block px-3 py-2 rounded hover:bg-sub">
               {s.label}
             </a>
           </li>

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -2,6 +2,14 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --bg-color: #F2D4CF;
+  --text-color: #2E2A2B;
+  --sub-color: #C48E86;
+  --sub-alt-color: #BFB6B0;
+  --main-color: #A56E63;
+}
+
 body {
   @apply font-sans;
   color: var(--text-color);

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -2,7 +2,15 @@
 module.exports = {
   content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}", "./pages/**/*.{ts,tsx}"],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        bg: "var(--bg-color)",
+        text: "var(--text-color)",
+        sub: "var(--sub-color)",
+        'sub-alt': "var(--sub-alt-color)",
+        main: "var(--main-color)",
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- define Tailwind color utilities that read from CSS variables
- replace inline styles in layout, sidebar, and cards with theme-aware classes
- seed CSS variables with default palette to avoid flashes

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a11582f208325b45cef7c2b04d893