### PR TITLE
refactor: simplify smokey background

### DIFF
--- a/web/components/SmokeyBackground.tsx
+++ b/web/components/SmokeyBackground.tsx
@@ -2,20 +2,13 @@ import React from "react";
 
 export default function SmokeyBackground() {
   return (
-    <svg
+    <div
       className="pointer-events-none fixed inset-0 z-0"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <filter id="smoke">
-        <feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="5" seed="2">
-          <animate attributeName="baseFrequency" dur="60s" values="0.9;0.8;0.9" repeatCount="indefinite" />
-        </feTurbulence>
-        <feColorMatrix type="saturate" values="0" />
-        <feComponentTransfer>
-          <feFuncA type="linear" slope="0.5" />
-        </feComponentTransfer>
-      </filter>
-      <rect width="100%" height="100%" filter="url(#smoke)" fill="var(--main-color)" opacity="0.2" />
-    </svg>
+      style={{
+        backgroundImage: "url('/smoke.svg')",
+        backgroundRepeat: "repeat",
+        color: "var(--main-color)",
+      }}
+    />
   );
 }

--- a/web/public/smoke.svg
+++ b/web/public/smoke.svg
@@ -1,12 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="400" height="400">
   <filter id="s">
-    <feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="5" seed="2">
-      <animate attributeName="baseFrequency" dur="60s" values="0.9;0.8;0.9" repeatCount="indefinite" />
-    </feTurbulence>
+    <feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="5" seed="2" />
     <feColorMatrix type="saturate" values="0" />
     <feComponentTransfer>
-      <feFuncA type="linear" slope="0.3" />
+      <feFuncA type="linear" slope="0.5" />
     </feComponentTransfer>
   </filter>
-  <rect width="100%" height="100%" filter="url(#s)" />
+  <rect width="100%" height="100%" filter="url(#s)" fill="currentColor" opacity="0.2" />
 </svg>

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -7,17 +7,3 @@ body {
   color: var(--text-color);
   background-color: var(--bg-color);
 }
-
-@keyframes smoke {
-  from {
-    background-position: 0 0;
-  }
-  to {
-    background-position: 200% 200%;
-  }
-}
-
-.smoke-animation {
-  background-size: 200% 200%;
-  animation: smoke 60s linear infinite;
-}


### PR DESCRIPTION
## Summary
- simplify SmokeyBackground to static noise using a tiled SVG
- drop unused smoke keyframes and animation class
- provide static SVG asset without animation for theming

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689a1159dbcc8325ae7169d90213202b