### PR TITLE
feat: add dark gradient theme and glass cards

### DIFF
--- a/web/components/Card.tsx
+++ b/web/components/Card.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from "react";
 export default function Card({ title, children, tooltip }: { title: string; children: ReactNode; tooltip?: string }) {
   return (
     <div
-      className="rounded-xl border p-6 shadow-md backdrop-blur bg-sub-alt border-sub"
+      className="rounded-xl border border-white/10 bg-white/10 p-6 shadow-md backdrop-blur-md"
       title={tooltip}
     >
       <h2 className="text-sm font-semibold mb-4 text-sub">

--- a/web/components/SmokeyBackground.tsx
+++ b/web/components/SmokeyBackground.tsx
@@ -5,9 +5,12 @@ export default function SmokeyBackground() {
     <div
       className="pointer-events-none fixed inset-0 z-0"
       style={{
-        backgroundImage: "url('/smoke.svg')",
-        backgroundRepeat: "repeat",
-        color: "var(--main-color)",
+        background:
+          "radial-gradient(circle at 25% 20%, rgba(128,90,213,0.25), transparent 60%), " +
+          "radial-gradient(circle at 75% 0%, rgba(110,231,183,0.25), transparent 55%), " +
+          "radial-gradient(circle at 80% 70%, rgba(236,72,153,0.2), transparent 55%), " +
+          "#0b0e1c",
+        filter: "blur(80px)",
       }}
     />
   );

--- a/web/lib/useThemePalette.ts
+++ b/web/lib/useThemePalette.ts
@@ -5,20 +5,20 @@ export interface Palette {
   series: string[];
 }
 
-// Static dark palette similar to GPT5 dark mode
+// Palette tuned for the new gradient theme
 const palette: Palette = {
-  text: "#e5e7eb",
-  subtext: "#9ca3af",
-  surfaces: "#2a2b32",
+  text: "#e2e8f0",
+  subtext: "#94a3b8",
+  surfaces: "rgba(255,255,255,0.05)",
   series: [
-    "#10A37F",
-    "#7AA2F7",
-    "#FF7B72",
-    "#F6C177",
-    "#C4B5FD",
+    "#5EEAD4",
+    "#A78BFA",
     "#F472B6",
-    "#93C5FD",
-    "#FACC15"
+    "#34D399",
+    "#818CF8",
+    "#FB7185",
+    "#2DD4BF",
+    "#C084FC"
   ]
 };
 

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -3,12 +3,12 @@
 @tailwind utilities;
 
 :root {
-  /* Static dark theme inspired by GPT5 dark mode */
-  --bg-color: #202123;
-  --text-color: #e5e7eb;
-  --sub-color: #4b5563;
-  --sub-alt-color: #2a2b32;
-  --main-color: #10a37f;
+  /* Deep navy theme with accent blooms */
+  --bg-color: #0b0e1c;
+  --text-color: #e2e8f0;
+  --sub-color: #94a3b8;
+  --sub-alt-color: rgba(255,255,255,0.05);
+  --main-color: #5eead4;
 }
 
 body {


### PR DESCRIPTION
## Summary
- implement deep navy gradient background with purple, teal and pink blooms
- adopt glassy blurred cards so charts stand out
- unify chart colors with a refreshed palette

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a1fee04748325afcd663f3e891bfc