### PR TITLE
Add KPI strip with sparklines and normalized metrics

### DIFF
--- a/web/components/KpiCard.tsx
+++ b/web/components/KpiCard.tsx
@@ -1,0 +1,60 @@
+import Chart from "@/components/Chart";
+import useThemePalette from "@/lib/useThemePalette";
+
+interface KpiCardProps {
+  title: string;
+  value: number;
+  trend?: number[];
+  delta?: number; // percentage
+  tooltip?: string;
+}
+
+const formatNumber = (n: number) => {
+  const abs = Math.abs(n);
+  if (abs >= 1_000_000) return `${(n / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
+  if (abs >= 1_000) return `${(n / 1_000).toFixed(1).replace(/\.0$/, "")}k`;
+  return n.toLocaleString();
+};
+
+export default function KpiCard({ title, value, trend = [], delta, tooltip }: KpiCardProps) {
+  const palette = useThemePalette();
+
+  const option = {
+    grid: { left: 0, right: 0, top: 0, bottom: 0 },
+    xAxis: { type: "category", show: false, data: trend.map((_, i) => i) },
+    yAxis: { type: "value", show: false },
+    series: [
+      {
+        type: "line",
+        data: trend,
+        smooth: true,
+        showSymbol: false,
+        lineStyle: { width: 1, color: palette.series[0] },
+        areaStyle: { color: palette.series[0], opacity: 0.3 },
+      },
+    ],
+  };
+
+  return (
+    <div
+      className="rounded-xl border border-white/10 bg-white/10 p-4 shadow-md backdrop-blur-md"
+      title={tooltip}
+    >
+      <div className="flex items-center justify-between mb-1">
+        <h2 className="text-sm font-semibold text-sub">{title}</h2>
+        {delta !== undefined && (
+          <span
+            className={`text-xs px-2 py-0.5 rounded-full ${
+              delta >= 0 ? "bg-green-500/20 text-green-300" : "bg-red-500/20 text-red-300"
+            }`}
+          >
+            {delta >= 0 ? "+" : ""}
+            {delta.toFixed(1)}%
+          </span>
+        )}
+      </div>
+      <div className="text-2xl font-bold">{formatNumber(value)}</div>
+      {trend.length > 0 && <Chart option={option} height={40} />}
+    </div>
+  );
+}

--- a/web/components/KpiStrip.tsx
+++ b/web/components/KpiStrip.tsx
@@ -1,0 +1,111 @@
+import KpiCard from "@/components/KpiCard";
+
+interface Props {
+  kpis: any;
+  startDate?: string;
+  endDate?: string;
+}
+
+function dateFilter(day: string, start?: string, end?: string) {
+  if (start && day < start) return false;
+  if (end && day > end) return false;
+  return true;
+}
+
+function aggregate(tl: any[], key: string, start?: string, end?: string) {
+  const map: Record<string, number> = {};
+  tl.filter((r: any) => dateFilter(r.day, start, end)).forEach((r: any) => {
+    map[r.day] = (map[r.day] || 0) + r[key];
+  });
+  const days = Object.keys(map).sort();
+  return { days, values: days.map((d) => map[d]) };
+}
+
+function prevSum(tl: any[], key: string, firstDay: string, len: number) {
+  const prevEnd = new Date(firstDay);
+  prevEnd.setDate(prevEnd.getDate() - 1);
+  const prevStart = new Date(firstDay);
+  prevStart.setDate(prevStart.getDate() - len);
+  const fmt = (d: Date) => d.toISOString().slice(0, 10);
+  const s = fmt(prevStart);
+  const e = fmt(prevEnd);
+  const map: Record<string, number> = {};
+  tl.filter((r: any) => r.day >= s && r.day <= e).forEach((r: any) => {
+    map[r.day] = (map[r.day] || 0) + r[key];
+  });
+  return Object.values(map).reduce((a, b) => a + b, 0);
+}
+
+export default function KpiStrip({ kpis, startDate, endDate }: Props) {
+  const msgAgg = aggregate(kpis.timeline_messages || [], "messages", startDate, endDate);
+  const wordAgg = aggregate(kpis.timeline_words || [], "words", startDate, endDate);
+
+  const totalMessages = msgAgg.values.reduce((s, n) => s + n, 0);
+  const totalWords = wordAgg.values.reduce((s, n) => s + n, 0);
+
+  const prevMessages = msgAgg.days.length
+    ? prevSum(kpis.timeline_messages || [], "messages", msgAgg.days[0], msgAgg.days.length)
+    : 0;
+  const prevWords = wordAgg.days.length
+    ? prevSum(kpis.timeline_words || [], "words", wordAgg.days[0], wordAgg.days.length)
+    : 0;
+
+  const delta = (cur: number, prev: number) => (prev > 0 ? ((cur - prev) / prev) * 100 : 0);
+
+  const perK = (count: number) => (totalWords > 0 ? count / (totalWords / 1000) : 0);
+
+  const metrics = [
+    {
+      title: "Messages",
+      value: totalMessages,
+      trend: msgAgg.values,
+      delta: delta(totalMessages, prevMessages),
+      tooltip: "Total messages exchanged in selected date range",
+    },
+    {
+      title: "Words",
+      value: totalWords,
+      trend: wordAgg.values,
+      delta: delta(totalWords, prevWords),
+      tooltip: "Total words sent in selected date range",
+    },
+    {
+      title: "We-ness ratio",
+      value: kpis.we_ness_ratio || 0,
+      trend: wordAgg.values.map(() => kpis.we_ness_ratio || 0),
+      tooltip: "Share of 'we/us/our' versus first-person pronouns",
+    },
+    {
+      title: "Questions/1k words",
+      value: perK(kpis.questions?.total || 0),
+      trend: wordAgg.values.map(() => perK(kpis.questions?.total || 0)),
+      tooltip: "Questions per thousand words",
+    },
+    {
+      title: "Attachments/1k words",
+      value: perK(kpis.media_total || 0),
+      trend: wordAgg.values.map(() => perK(kpis.media_total || 0)),
+      tooltip: "Messages with media or files per thousand words",
+    },
+    {
+      title: "Affection/1k words",
+      value: perK(kpis.affection_hits || 0),
+      trend: wordAgg.values.map(() => perK(kpis.affection_hits || 0)),
+      tooltip: "Affectionate words or emojis per thousand words",
+    },
+    {
+      title: "Profanity/1k words",
+      value: perK(kpis.profanity_hits || 0),
+      trend: wordAgg.values.map(() => perK(kpis.profanity_hits || 0)),
+      tooltip: "Common profanity per thousand words",
+    },
+  ];
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-7 gap-4 mt-4">
+      {metrics.map((m) => (
+        <KpiCard key={m.title} {...m} />
+      ))}
+    </div>
+  );
+}

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from "react";
 import { getKPIs, uploadFile, getConflicts } from "@/lib/api";
 import Card from "@/components/Card";
 import Chart from "@/components/Chart";
+import KpiStrip from "@/components/KpiStrip";
 import useThemePalette from "@/lib/useThemePalette";
 
 type KPI = any;
@@ -103,14 +104,6 @@ async function fetchConflicts() {
     });
     return participants.map(p => ({ sender: p, messages: msgMap[p]||0, words: wordMap[p]||0 }));
   }, [kpis, startDate, endDate, participants]);
-
-  const filteredTotals = useMemo(() => {
-    if (!kpis) return { messages: 0, words: 0 };
-    if (!startDate && !endDate) return kpis.totals;
-    const totalMessages = (kpis.timeline_messages || []).filter((r:any)=>dateFilter(r.day)).reduce((s:number,r:any)=>s+r.messages,0);
-    const totalWords = (kpis.timeline_words || []).filter((r:any)=>dateFilter(r.day)).reduce((s:number,r:any)=>s+r.words,0);
-    return { messages: totalMessages, words: totalWords };
-  }, [kpis, startDate, endDate]);
 
   const handleZoom = (e: any) => {
     const dz = Array.isArray(e.batch) && e.batch.length ? e.batch[0] : e;
@@ -457,20 +450,7 @@ async function fetchConflicts() {
                 <input type="date" value={endDate} onChange={e=>setEndDate(e.target.value)} className="bg-white/10 rounded px-2 py-1" />
               </div>
             </div>
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mt-4">
-              <Card title="Messages" tooltip="Total messages exchanged in selected date range">
-                <div className="text-2xl font-bold">{filteredTotals.messages}</div>
-              </Card>
-              <Card title="Words" tooltip="Total words sent in selected date range">
-                <div className="text-2xl font-bold">{filteredTotals.words}</div>
-              </Card>
-              <Card title="We-ness ratio" tooltip="Share of 'we/us/our' versus first-person pronouns">
-                <div className="text-2xl font-bold">{kpis.we_ness_ratio.toFixed(2)}</div>
-              </Card>
-              <Card title="Profanity hits" tooltip="Count of messages containing common profanity">
-                <div className="text-2xl font-bold">{kpis.profanity_hits}</div>
-              </Card>
-            </div>
+            <KpiStrip kpis={kpis} startDate={startDate} endDate={endDate} />
           </section>
 
           <section id="analytics" className="grid grid-cols-1 xl:grid-cols-3 gap-6">


### PR DESCRIPTION
## Summary
- Introduce `KpiCard` component for metric display with sparklines, delta badges, and short-scale number formatting.
- Implement `KpiStrip` to summarize chat KPIs, including per‑1k word normalization and descriptive tooltips.
- Mount `KpiStrip` at the top of the index page to provide an overview of key metrics.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a27ec984c8325a1db5c97e2904608