### PR TITLE
feat: add unified timeline with brush selection

### DIFF
--- a/web/components/UnifiedTimeline.tsx
+++ b/web/components/UnifiedTimeline.tsx
@@ -1,0 +1,175 @@
+import { useMemo } from "react";
+import Chart from "@/components/Chart";
+import useThemePalette from "@/lib/useThemePalette";
+import { useDateRange } from "@/lib/DateRangeContext";
+
+interface TimelineEntry {
+  day: string;
+  messages?: number;
+  words?: number;
+}
+
+interface UnifiedTimelineProps {
+  timelineMessages: TimelineEntry[];
+  timelineWords: TimelineEntry[];
+  conflictDates?: string[];
+  affectionDates?: string[];
+}
+
+function movingAvg(arr: number[], window = 7): number[] {
+  const res: number[] = [];
+  for (let i = 0; i < arr.length; i++) {
+    const start = Math.max(0, i - window + 1);
+    const slice = arr.slice(start, i + 1);
+    const avg = slice.reduce((s, v) => s + v, 0) / slice.length;
+    res.push(avg);
+  }
+  return res;
+}
+
+export default function UnifiedTimeline({
+  timelineMessages,
+  timelineWords,
+  conflictDates = [],
+  affectionDates = [],
+}: UnifiedTimelineProps) {
+  const palette = useThemePalette();
+  const { setStartDate, setEndDate } = useDateRange();
+
+  const data = useMemo(() => {
+    const msgMap: Record<string, number> = {};
+    const wordMap: Record<string, number> = {};
+    timelineMessages.forEach(r => {
+      msgMap[r.day] = (msgMap[r.day] || 0) + (r.messages || 0);
+    });
+    timelineWords.forEach(r => {
+      wordMap[r.day] = (wordMap[r.day] || 0) + (r.words || 0);
+    });
+    const days = Array.from(new Set([...Object.keys(msgMap), ...Object.keys(wordMap)])).sort();
+    const msgSeries = days.map(d => msgMap[d] || 0);
+    const wordSeries = days.map(d => wordMap[d] || 0);
+    return {
+      days,
+      msgSeries,
+      wordSeries,
+      maMsg: movingAvg(msgSeries),
+      maWord: movingAvg(wordSeries),
+    };
+  }, [timelineMessages, timelineWords]);
+
+  const option = useMemo(() => {
+    const conflicts = conflictDates.map(d => ({ value: [d, 0] }));
+    const affection = affectionDates.map(d => ({ value: [d, 0] }));
+    return {
+      backgroundColor: "transparent",
+      textStyle: { color: palette.text },
+      tooltip: { trigger: "axis" },
+      legend: {
+        data: [
+          "Messages",
+          "Words",
+          "7d avg messages",
+          "7d avg words",
+          ...(conflicts.length ? ["Conflicts"] : []),
+          ...(affection.length ? ["Affection"] : []),
+        ],
+        textStyle: { color: palette.text },
+      },
+      xAxis: {
+        type: "category",
+        data: data.days,
+        axisLabel: { color: palette.text },
+        axisLine: { lineStyle: { color: palette.subtext } },
+      },
+      yAxis: [
+        {
+          type: "value",
+          name: "Messages",
+          axisLabel: { color: palette.text },
+          axisLine: { lineStyle: { color: palette.subtext } },
+        },
+        {
+          type: "value",
+          name: "Words",
+          axisLabel: { color: palette.text },
+          axisLine: { lineStyle: { color: palette.subtext } },
+          position: "right",
+        },
+      ],
+      brush: { toolbox: ["rect", "clear"], xAxisIndex: "all" },
+      series: [
+        {
+          name: "Messages",
+          type: "bar",
+          data: data.msgSeries,
+          itemStyle: { color: palette.series[0] },
+          yAxisIndex: 0,
+        },
+        {
+          name: "Words",
+          type: "bar",
+          data: data.wordSeries,
+          itemStyle: { color: palette.series[1] },
+          yAxisIndex: 1,
+        },
+        {
+          name: "7d avg messages",
+          type: "line",
+          data: data.maMsg,
+          yAxisIndex: 0,
+          smooth: true,
+          lineStyle: { color: palette.series[0] },
+        },
+        {
+          name: "7d avg words",
+          type: "line",
+          data: data.maWord,
+          yAxisIndex: 1,
+          smooth: true,
+          lineStyle: { color: palette.series[1] },
+        },
+        ...(conflicts.length
+          ? [
+              {
+                name: "Conflicts",
+                type: "scatter",
+                data: conflicts,
+                symbolSize: 8,
+                itemStyle: { color: palette.series[2] },
+                yAxisIndex: 0,
+              },
+            ]
+          : []),
+        ...(affection.length
+          ? [
+              {
+                name: "Affection",
+                type: "scatter",
+                data: affection,
+                symbolSize: 8,
+                itemStyle: { color: palette.series[3] },
+                yAxisIndex: 0,
+              },
+            ]
+          : []),
+      ],
+    };
+  }, [data, conflictDates, affectionDates, palette]);
+
+  const handleBrush = (params: any) => {
+    const areas = params?.batch?.[0]?.areas;
+    if (!areas || !areas.length) return;
+    const range = areas[0].coordRange as [number, number];
+    const startIdx = Math.floor(range[0]);
+    const endIdx = Math.floor(range[1]);
+    const start = data.days[Math.max(0, startIdx)];
+    const end = data.days[Math.min(data.days.length - 1, endIdx)];
+    if (start && end) {
+      setStartDate(start);
+      setEndDate(end);
+    }
+  };
+
+  return <Chart option={option} height={260} onEvents={{ brushselected: handleBrush }} />;
+}
+

--- a/web/lib/DateRangeContext.tsx
+++ b/web/lib/DateRangeContext.tsx
@@ -1,0 +1,18 @@
+import { createContext, useContext } from "react";
+
+interface DateRangeContextType {
+  startDate: string;
+  endDate: string;
+  setStartDate: (d: string) => void;
+  setEndDate: (d: string) => void;
+}
+
+export const DateRangeContext = createContext<DateRangeContextType>({
+  startDate: "",
+  endDate: "",
+  setStartDate: () => {},
+  setEndDate: () => {},
+});
+
+export const useDateRange = () => useContext(DateRangeContext);
+

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -3,7 +3,9 @@ import { useEffect, useMemo, useState } from "react";
 import { getKPIs, uploadFile, getConflicts } from "@/lib/api";
 import Card from "@/components/Card";
 import Chart from "@/components/Chart";
+import UnifiedTimeline from "@/components/UnifiedTimeline";
 import useThemePalette from "@/lib/useThemePalette";
+import { DateRangeContext } from "@/lib/DateRangeContext";
 
 type KPI = any;
 const formatNumber = (n: number) => n.toLocaleString();
@@ -17,12 +19,9 @@ export default function Home() {
   const [conflictErr, setConflictErr] = useState<string | null>(null);
   const [conflictProgress, setConflictProgress] = useState<{current:number,total:number}|null>(null);
   const [selectedConflict, setSelectedConflict] = useState<any | null>(null);
-  const [timelineMetric, setTimelineMetric] = useState<"messages" | "words">("messages");
-  const [showTrend, setShowTrend] = useState(false);
   const [heatPerson, setHeatPerson] = useState<string>("All");
   const [startDate, setStartDate] = useState<string>("");
   const [endDate, setEndDate] = useState<string>("");
-  const [zoomRange, setZoomRange] = useState<[number, number] | null>(null);
   const palette = useThemePalette();
 
   useEffect(() => {
@@ -40,9 +39,6 @@ export default function Home() {
     }
   }, [kpis]);
 
-   useEffect(() => {
-    setZoomRange(null);
-  }, [timelineMetric, startDate, endDate, kpis]);
 
 async function fetchConflicts() {
   try {
@@ -112,18 +108,9 @@ async function fetchConflicts() {
     return { messages: totalMessages, words: totalWords };
   }, [kpis, startDate, endDate]);
 
-  const handleZoom = (e: any) => {
-    const dz = Array.isArray(e.batch) && e.batch.length ? e.batch[0] : e;
-    if (dz.start == null || dz.end == null) return;
-    const key = timelineMetric === "messages" ? "timeline_messages" : "timeline_words";
-    const tl = (kpis?.[key] || []).filter((r:any)=>dateFilter(r.day));
-    const days = Array.from(new Set(tl.map((r:any)=>r.day))).sort();
-    if (days.length < 2) return;
-    const len = days.length - 1;
-    const startIdx = Math.round((dz.start / 100) * len);
-    const endIdx = Math.round((dz.end / 100) * len);
-    setZoomRange([startIdx, endIdx]);
-  };
+  const conflictDates = useMemo(() => conflicts.flatMap(p => (p.conflicts || []).map((c:any) => c.date)), [conflicts]);
+  const affectionDates = useMemo(() => (kpis?.affection_timeline || []).map((r:any) => r.day), [kpis]);
+
 
   const messagesOption = () => {
     const rows = filteredBySender;
@@ -225,104 +212,6 @@ async function fetchConflicts() {
     };
   };
 
-  const timelineOption = () => {
-    const key = timelineMetric === "messages" ? "timeline_messages" : "timeline_words";
-    const tlAll = (kpis?.[key] || []).filter((r:any)=>dateFilter(r.day));
-    const allDays: string[] = Array.from(new Set<string>(tlAll.map((r:any)=>r.day))).sort();
-    let startIdx = zoomRange ? zoomRange[0] : 0;
-    let endIdx = zoomRange ? zoomRange[1] : allDays.length - 1;
-    startIdx = Math.max(0, Math.min(startIdx, allDays.length - 1));
-    endIdx = Math.max(0, Math.min(endIdx, allDays.length - 1));
-    if (endIdx < startIdx) endIdx = startIdx;
-    const visibleDays = allDays.slice(startIdx, endIdx + 1);
-    const visibleTl = tlAll.filter((r:any) => {
-      const idx = allDays.indexOf(r.day);
-      return idx >= startIdx && idx <= endIdx;
-    });
-    const senders: string[] = Array.from(new Set(visibleTl.map((r:any)=>r.sender)));
-    const useWeeks = visibleDays.length > 90;
-    let axis: string[] = [];
-    const dataPerSender: Record<string, number[]> = {};
-    senders.forEach(s => dataPerSender[s] = []);
-    if (useWeeks) {
-      const getWeekStart = (dStr: string) => {
-        const d = new Date(dStr + "T00:00:00Z");
-        const day = d.getUTCDay();
-        const diff = (day + 6) % 7;
-        d.setUTCDate(d.getUTCDate() - diff);
-        return d.toISOString().slice(0,10);
-      };
-      const weekMap: Record<string, Record<string, number>> = {};
-      visibleTl.forEach((r:any) => {
-        const week = getWeekStart(r.day);
-        if (!weekMap[week]) weekMap[week] = {};
-        weekMap[week][r.sender] = (weekMap[week][r.sender] || 0) + (timelineMetric === "messages" ? r.messages : r.words);
-      });
-      axis = Object.keys(weekMap).sort();
-      senders.forEach(s => {
-        dataPerSender[s] = axis.map(w => weekMap[w][s] || 0);
-      });
-    } else {
-      const dayMap: Record<string, Record<string, number>> = {};
-      visibleTl.forEach((r:any) => {
-        if (!dayMap[r.day]) dayMap[r.day] = {};
-        dayMap[r.day][r.sender] = (timelineMetric === "messages" ? r.messages : r.words);
-      });
-      axis = visibleDays;
-      senders.forEach(s => {
-        dataPerSender[s] = axis.map(d => (dayMap[d] && dayMap[d][s]) || 0);
-      });
-    }
-    const series = senders.map((s: string, i:number) => {
-      const values = dataPerSender[s];
-      let markLine: any = undefined;
-      if (showTrend && values.length > 1) {
-        const n = values.length;
-        let sumX = 0, sumY = 0, sumXY = 0, sumXX = 0;
-        for (let j = 0; j < n; j++) {
-          sumX += j;
-          sumY += values[j];
-          sumXY += j * values[j];
-          sumXX += j * j;
-        }
-        const denom = n * sumXX - sumX * sumX || 1;
-        const slope = (n * sumXY - sumX * sumY) / denom;
-        const intercept = (sumY - slope * sumX) / n;
-        const startY = intercept;
-        const endY = intercept + slope * (n - 1);
-        markLine = {
-          symbol: "none",
-          lineStyle: { type: "dashed", color: colorMap[s] || palette.series[i % palette.series.length] },
-          data: [[{ coord: [axis[0], startY] }, { coord: [axis[n - 1], endY] }]]
-        };
-      }
-      return {
-        name: s,
-        type: "line",
-        smooth: true,
-        lineStyle: { width: 3 },
-        itemStyle: { color: colorMap[s] || palette.series[i % palette.series.length] },
-        data: values,
-        ...(markLine ? { markLine } : {})
-      };
-    });
-    const lenAll = Math.max(1, allDays.length - 1);
-    const startPercent = (startIdx / lenAll) * 100;
-    const endPercent = (endIdx / lenAll) * 100;
-    return {
-      backgroundColor: "transparent",
-      textStyle: { color: palette.text },
-      tooltip: { valueFormatter: (value: number) => formatNumber(value) },
-      dataZoom: [
-        { type: 'inside', start: startPercent, end: endPercent },
-        { type: 'slider', start: startPercent, end: endPercent }
-      ],
-      legend: { data: senders, textStyle:{color: palette.text} },
-      xAxis: { type: "category", data: axis, axisLabel:{color: palette.text}, axisLine:{lineStyle:{color: palette.subtext}} },
-      yAxis: { type: "value", axisLabel:{color: palette.text, formatter: (value:number) => formatNumber(value)}, axisLine:{lineStyle:{color: palette.subtext}} },
-      series
-    };
-  };
 
   const heatOption = () => {
     const hm = (kpis?.heatmap || []).filter((r:any)=> heatPerson==="All" ? true : r.sender===heatPerson);
@@ -434,6 +323,7 @@ async function fetchConflicts() {
   };
 
   return (
+    <DateRangeContext.Provider value={{ startDate, endDate, setStartDate, setEndDate }}>
     <>
       <div className="flex items-center justify-end">
         <label className="px-4 py-2 rounded-xl bg-white/10 hover:bg-white/20 transition cursor-pointer">
@@ -472,6 +362,16 @@ async function fetchConflicts() {
               </Card>
             </div>
           </section>
+          <section id="timeline" className="mt-6">
+            <Card title="Timeline">
+              <UnifiedTimeline
+                timelineMessages={kpis.timeline_messages || []}
+                timelineWords={kpis.timeline_words || []}
+                conflictDates={conflictDates}
+                affectionDates={affectionDates}
+              />
+            </Card>
+          </section>
 
           <section id="analytics" className="grid grid-cols-1 xl:grid-cols-3 gap-6">
             <div>
@@ -482,20 +382,6 @@ async function fetchConflicts() {
             <div>
               <Card title="Words by sender">
                 <Chart option={wordsOption()} height={260} />
-              </Card>
-            </div>
-            <div className="xl:row-span-2">
-              <Card title="Timeline">
-                <div className="flex gap-2 mb-2 items-center">
-                  <button onClick={()=>setTimelineMetric("messages")} className={`px-3 py-1 rounded-full ${timelineMetric==="messages"?"bg-white/20":"bg-white/10"}`}>Messages</button>
-                  <button onClick={()=>setTimelineMetric("words")} className={`px-3 py-1 rounded-full ${timelineMetric==="words"?"bg-white/20":"bg-white/10"}`}>Words</button>
-                  <label className="flex items-center text-sm ml-auto">
-                    <input type="checkbox" className="mr-1" checked={showTrend} onChange={e=>setShowTrend(e.target.checked)} />
-                    Trend
-                  </label>
-                </div>
-                <Chart option={timelineOption()} height={360} onEvents={{ datazoom: handleZoom }} />
-                {(!kpis || (kpis[timelineMetric==="messages"?"timeline_messages":"timeline_words"]||[]).length===0) && <div className="text-sm text-gray-400 mt-2">No timeline data yet.</div>}
               </Card>
             </div>
             <div>
@@ -619,5 +505,6 @@ async function fetchConflicts() {
         )}
         <div className="text-xs text-gray-400">v0.2.9 — visual refinements • API v{apiVersion}</div>
     </>
+    </DateRangeContext.Provider>
   );
 }


### PR DESCRIPTION
## Summary
- add DateRangeContext and UnifiedTimeline component for combined message/word timeline
- display optional conflict and affection markers with 7-day moving averages
- wire brush selection to global date range and embed timeline on dashboard

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a27f80f0c8325a37ef62f462720fc