### PR TITLE
Add weekly sender share chart

### DIFF
--- a/web/components/SenderShareChart.tsx
+++ b/web/components/SenderShareChart.tsx
@@ -1,0 +1,92 @@
+import Chart from "@/components/Chart";
+import useThemePalette from "@/lib/useThemePalette";
+
+interface TimelinePoint {
+  day: string;
+  sender: string;
+  messages?: number;
+  words?: number;
+}
+
+interface Props {
+  data: TimelinePoint[];
+  participants: string[];
+  colorMap: Record<string, string>;
+  zoomRange: [number, number] | null;
+}
+
+export default function SenderShareChart({ data, participants, colorMap, zoomRange }: Props) {
+  const palette = useThemePalette();
+
+  const allDays = Array.from(new Set(data.map(r => r.day))).sort();
+  let startIdx = zoomRange ? zoomRange[0] : 0;
+  let endIdx = zoomRange ? zoomRange[1] : allDays.length - 1;
+  startIdx = Math.max(0, Math.min(startIdx, allDays.length - 1));
+  endIdx = Math.max(0, Math.min(endIdx, allDays.length - 1));
+  if (endIdx < startIdx) endIdx = startIdx;
+  const visibleDays = allDays.slice(startIdx, endIdx + 1);
+
+  const getWeekStart = (dStr: string) => {
+    const d = new Date(dStr + "T00:00:00Z");
+    const day = d.getUTCDay();
+    const diff = (day + 6) % 7; // Monday start
+    d.setUTCDate(d.getUTCDate() - diff);
+    return d.toISOString().slice(0, 10);
+  };
+
+  const weekMap: Record<string, Record<string, number>> = {};
+  data
+    .filter(r => visibleDays.includes(r.day))
+    .forEach(r => {
+      const week = getWeekStart(r.day);
+      if (!weekMap[week]) weekMap[week] = {};
+      const val = (r.messages ?? r.words) || 0;
+      weekMap[week][r.sender] = (weekMap[week][r.sender] || 0) + val;
+    });
+
+  const weeks = Object.keys(weekMap).sort();
+  const totals = weeks.map(w =>
+    participants.reduce((sum, p) => sum + (weekMap[w][p] || 0), 0)
+  );
+
+  const series = participants.map(p => ({
+    name: p,
+    type: "line",
+    stack: "total",
+    areaStyle: { opacity: 0.8 },
+    lineStyle: { width: 0 },
+    symbol: "none",
+    itemStyle: { color: colorMap[p] },
+    data: weeks.map((w, i) => {
+      const val = weekMap[w][p] || 0;
+      const total = totals[i] || 1;
+      return (val / total) * 100;
+    })
+  }));
+
+  const option = {
+    backgroundColor: "transparent",
+    textStyle: { color: palette.text },
+    tooltip: {
+      trigger: "axis",
+      axisPointer: { type: "shadow" },
+      valueFormatter: (value: number) => `${value.toFixed(1)}%`
+    },
+    legend: { data: participants, textStyle: { color: palette.text } },
+    xAxis: {
+      type: "category",
+      data: weeks,
+      axisLabel: { color: palette.text },
+      axisLine: { lineStyle: { color: palette.subtext } }
+    },
+    yAxis: {
+      type: "value",
+      max: 100,
+      axisLabel: { color: palette.text, formatter: (v: number) => `${v}%` },
+      axisLine: { lineStyle: { color: palette.subtext } }
+    },
+    series
+  };
+
+  return <Chart option={option} height={260} />;
+}

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -4,6 +4,7 @@ import { getKPIs, uploadFile, getConflicts } from "@/lib/api";
 import Card from "@/components/Card";
 import Chart from "@/components/Chart";
 import useThemePalette from "@/lib/useThemePalette";
+import SenderShareChart from "@/components/SenderShareChart";
 
 type KPI = any;
 const formatNumber = (n: number) => n.toLocaleString();
@@ -111,6 +112,11 @@ async function fetchConflicts() {
     const totalWords = (kpis.timeline_words || []).filter((r:any)=>dateFilter(r.day)).reduce((s:number,r:any)=>s+r.words,0);
     return { messages: totalMessages, words: totalWords };
   }, [kpis, startDate, endDate]);
+
+  const timelineData = useMemo(() => {
+    const key = timelineMetric === "messages" ? "timeline_messages" : "timeline_words";
+    return (kpis?.[key] || []).filter((r: any) => dateFilter(r.day));
+  }, [kpis, timelineMetric, startDate, endDate]);
 
   const handleZoom = (e: any) => {
     const dz = Array.isArray(e.batch) && e.batch.length ? e.batch[0] : e;
@@ -507,6 +513,12 @@ async function fetchConflicts() {
               <Card title="Seconds to reply">
                 <Chart option={replyOption()} height={260} />
                 {(!kpis?.reply_simple || kpis.reply_simple.length===0) && <div className="text-sm text-gray-400 mt-2">No alternating replies detected yet.</div>}
+              </Card>
+            </div>
+            <div>
+              <Card title="Sender share over time">
+                <SenderShareChart data={timelineData} participants={participants} colorMap={colorMap} zoomRange={zoomRange} />
+                {timelineData.length === 0 && <div className="text-sm text-gray-400 mt-2">No timeline data yet.</div>}
               </Card>
             </div>
           </section>


### PR DESCRIPTION
## Summary
- visualize sender share over time with a 100% stacked area chart
- wire chart into analytics grid and sync to timeline brush range

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a2806dbec8325b073335bc5909235