### PR TITLE
feat: add reply time distribution chart

### DIFF
--- a/web/components/ReplyTimeDistribution.tsx
+++ b/web/components/ReplyTimeDistribution.tsx
@@ -1,0 +1,107 @@
+import { useMemo } from "react";
+import Chart from "@/components/Chart";
+import useThemePalette from "@/lib/useThemePalette";
+
+interface ReplyRecord {
+  to: string;
+  sec: number;
+  day?: string; // YYYY-MM-DD
+}
+
+interface Props {
+  data: ReplyRecord[];
+  startDate?: string;
+  endDate?: string;
+  height?: number;
+}
+
+function formatDuration(s: number): string {
+  if (s >= 3600) return `${(s / 3600).toFixed(1)} hr`;
+  if (s >= 60) return `${(s / 60).toFixed(1)} min`;
+  if (s >= 1) return `${s.toFixed(0)} s`;
+  return `${(s * 1000).toFixed(0)} ms`;
+}
+
+export default function ReplyTimeDistribution({ data, startDate, endDate, height = 260 }: Props) {
+  const palette = useThemePalette();
+
+  const filtered = useMemo(() => {
+    return data.filter(r => {
+      if (startDate && r.day && r.day < startDate) return false;
+      if (endDate && r.day && r.day > endDate) return false;
+      return true;
+    });
+  }, [data, startDate, endDate]);
+
+  const participants = useMemo(() => Array.from(new Set(filtered.map(r => r.to))).sort(), [filtered]);
+
+  const colorMap = useMemo(() => {
+    const map: Record<string, string> = {};
+    participants.forEach((p, i) => {
+      map[p] = palette.series[i % palette.series.length];
+    });
+    return map;
+  }, [participants, palette]);
+
+  const stats = useMemo(() => {
+    const q = (arr: number[], p: number) => {
+      const pos = (arr.length - 1) * p;
+      const base = Math.floor(pos);
+      const rest = pos - base;
+      if (arr[base + 1] !== undefined) {
+        return arr[base] + rest * (arr[base + 1] - arr[base]);
+      }
+      return arr[base];
+    };
+
+    return participants.map(p => {
+      const arr = filtered.filter(r => r.to === p).map(r => r.sec).sort((a, b) => a - b);
+      if (arr.length === 0) {
+        return { person: p, value: [0, 0, 0, 0, 0], median: 0, iqr: 0 };
+      }
+      const q1 = q(arr, 0.25);
+      const median = q(arr, 0.5);
+      const q3 = q(arr, 0.75);
+      const min = arr[0];
+      const max = arr[arr.length - 1];
+      return { person: p, value: [min, q1, median, q3, max], median, iqr: q3 - q1 };
+    }).filter(s => s.value[4] > 0);
+  }, [filtered, participants]);
+
+  const option = useMemo(() => ({
+    backgroundColor: "transparent",
+    textStyle: { color: palette.text },
+    tooltip: {
+      trigger: "item",
+      formatter: (param: any) => {
+        const st = stats[param.dataIndex];
+        return `${st.person}<br/>Median: ${formatDuration(st.median)}<br/>IQR: ${formatDuration(st.iqr)}`;
+      }
+    },
+    xAxis: {
+      type: "category",
+      data: stats.map(s => s.person),
+      axisLabel: { color: palette.text },
+      axisLine: { lineStyle: { color: palette.subtext } }
+    },
+    yAxis: {
+      type: "value",
+      name: "Reply time",
+      axisLabel: { color: palette.text, formatter: (v: number) => formatDuration(v) },
+      axisLine: { lineStyle: { color: palette.subtext } }
+    },
+    series: [
+      {
+        type: "boxplot",
+        data: stats.map(s => ({ value: s.value, itemStyle: { color: colorMap[s.person] } })),
+      }
+    ]
+  }), [stats, colorMap, palette]);
+
+  if (!stats.length) {
+    return <div className="text-sm text-gray-400">No reply time data.</div>;
+  }
+
+  return <Chart option={option} height={height} />;
+}
+

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from "react";
 import { getKPIs, uploadFile, getConflicts } from "@/lib/api";
 import Card from "@/components/Card";
 import Chart from "@/components/Chart";
+import ReplyTimeDistribution from "@/components/ReplyTimeDistribution";
 import useThemePalette from "@/lib/useThemePalette";
 
 type KPI = any;
@@ -155,27 +156,6 @@ async function fetchConflicts() {
         {
           type: "bar",
           data: rows.map((r:any)=>({ value: r.words, itemStyle: { color: colorMap[r.sender] } })),
-          barWidth: "40%"
-        }
-      ]
-    };
-  };
-
-  const replyOption = () => {
-    const rs = (kpis?.reply_simple || []) as Array<any>;
-    return {
-      backgroundColor: "transparent",
-      textStyle: { color: palette.text },
-      tooltip: { valueFormatter: (value: number) => formatNumber(value) },
-      xAxis: { type: "category", data: participants, axisLabel:{color: palette.text}, axisLine:{lineStyle:{color: palette.subtext}} },
-      yAxis: { type: "value", name: "seconds", axisLabel:{color: palette.text, formatter: (value:number) => formatNumber(value)}, axisLine:{lineStyle:{color: palette.subtext}} },
-      series: [
-        {
-          type: "bar",
-          data: participants.map(p => {
-            const row = rs.find((r:any)=>r.person===p) || {};
-            return { value: row.seconds || 0, itemStyle: { color: colorMap[p] } };
-          }),
           barWidth: "40%"
         }
       ]
@@ -504,9 +484,8 @@ async function fetchConflicts() {
               </Card>
             </div>
             <div>
-              <Card title="Seconds to reply">
-                <Chart option={replyOption()} height={260} />
-                {(!kpis?.reply_simple || kpis.reply_simple.length===0) && <div className="text-sm text-gray-400 mt-2">No alternating replies detected yet.</div>}
+              <Card title="Reply time distribution">
+                <ReplyTimeDistribution data={kpis?.reply_pairs || []} startDate={startDate} endDate={endDate} />
               </Card>
             </div>
           </section>


### PR DESCRIPTION
## Summary
- add `ReplyTimeDistribution` component to plot per-participant reply time distributions
- wire up `ReplyTimeDistribution` in main dashboard

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a28115e0c832597f6d159d3149aba