### PR TITLE
feat: add toggleable message/word chart

### DIFF
--- a/web/components/ColorLegend.tsx
+++ b/web/components/ColorLegend.tsx
@@ -1,0 +1,16 @@
+import { useParticipantColors } from "@/lib/ParticipantColors";
+
+export default function ColorLegend() {
+  const { participants, colorMap } = useParticipantColors();
+  if (!participants.length) return null;
+  return (
+    <div className="flex flex-wrap gap-4 text-sm">
+      {participants.map((p) => (
+        <span key={p} className="flex items-center gap-1">
+          <span className="w-3 h-3 rounded-full" style={{ backgroundColor: colorMap[p] }} />
+          {p}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/web/components/Layout.tsx
+++ b/web/components/Layout.tsx
@@ -4,6 +4,7 @@ import { ReactNode } from "react";
 
 import Sidebar from "@/components/Sidebar";
 import SmokeyBackground from "@/components/SmokeyBackground";
+import ColorLegend from "@/components/ColorLegend";
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (
@@ -16,10 +17,11 @@ export default function Layout({ children }: { children: ReactNode }) {
         <SmokeyBackground />
 
         <header className="relative z-10 border-b bg-sub-alt border-sub">
-          <div className="px-6 py-4">
+          <div className="px-6 py-4 flex flex-wrap items-center justify-between gap-4">
             <h1 className="text-2xl font-semibold text-main">
               WhatsApp Relationship Analytics
             </h1>
+            <ColorLegend />
           </div>
         </header>
         <div className="flex relative z-10">

--- a/web/components/MessageWordBySender.tsx
+++ b/web/components/MessageWordBySender.tsx
@@ -1,0 +1,82 @@
+import { useState } from "react";
+import Chart from "@/components/Chart";
+import useThemePalette from "@/lib/useThemePalette";
+import { useParticipantColors } from "@/lib/ParticipantColors";
+
+interface Row {
+  sender: string;
+  messages: number;
+  words: number;
+}
+
+const formatNumber = (n: number) => n.toLocaleString();
+
+export default function MessageWordBySender({ rows }: { rows: Row[] }) {
+  const palette = useThemePalette();
+  const { colorMap } = useParticipantColors();
+  const [view, setView] = useState<"messages" | "words" | "both">("messages");
+
+  const max = rows.reduce((m, r) => Math.max(m, r.messages, r.words), 0);
+
+  const option = (field: "messages" | "words") => ({
+    backgroundColor: "transparent",
+    textStyle: { color: palette.text },
+    tooltip: { valueFormatter: (value: number) => formatNumber(value) },
+    xAxis: {
+      type: "category",
+      data: rows.map((r) => r.sender),
+      axisLine: { lineStyle: { color: palette.subtext } },
+      axisLabel: { color: palette.text },
+    },
+    yAxis: {
+      type: "value",
+      max,
+      axisLine: { lineStyle: { color: palette.subtext } },
+      axisLabel: { color: palette.text, formatter: (v: number) => formatNumber(v) },
+    },
+    series: [
+      {
+        type: "bar",
+        data: rows.map((r) => ({ value: r[field], itemStyle: { color: colorMap[r.sender] } })),
+        barWidth: "40%",
+      },
+    ],
+  });
+
+  return (
+    <div>
+      <div className="flex gap-2 mb-2">
+        <button
+          onClick={() => setView("messages")}
+          className={`px-3 py-1 rounded-full ${view === "messages" ? "bg-white/20" : "bg-white/10"}`}
+        >
+          Messages
+        </button>
+        <button
+          onClick={() => setView("words")}
+          className={`px-3 py-1 rounded-full ${view === "words" ? "bg-white/20" : "bg-white/10"}`}
+        >
+          Words
+        </button>
+        <button
+          onClick={() => setView("both")}
+          className={`px-3 py-1 rounded-full ${view === "both" ? "bg-white/20" : "bg-white/10"}`}
+        >
+          Both
+        </button>
+      </div>
+      {view === "both" ? (
+        <div className="flex gap-4">
+          <div className="flex-1">
+            <Chart option={option("messages")} height={260} />
+          </div>
+          <div className="flex-1">
+            <Chart option={option("words")} height={260} />
+          </div>
+        </div>
+      ) : (
+        <Chart option={option(view)} height={260} />
+      )}
+    </div>
+  );
+}

--- a/web/lib/ParticipantColors.tsx
+++ b/web/lib/ParticipantColors.tsx
@@ -1,0 +1,38 @@
+import { createContext, useContext, useMemo, useState, ReactNode } from "react";
+import useThemePalette from "@/lib/useThemePalette";
+
+interface ParticipantColors {
+  participants: string[];
+  colorMap: Record<string, string>;
+  setParticipants: (p: string[]) => void;
+}
+
+const ParticipantColorsContext = createContext<ParticipantColors>({
+  participants: [],
+  colorMap: {},
+  setParticipants: () => {}
+});
+
+export function ParticipantColorsProvider({ children }: { children: ReactNode }) {
+  const palette = useThemePalette();
+  const [participants, setParticipants] = useState<string[]>([]);
+
+  const colorMap = useMemo(() => {
+    const map: Record<string, string> = {};
+    participants.forEach((p, i) => {
+      map[p] = palette.series[i % palette.series.length];
+    });
+    return map;
+  }, [participants, palette]);
+
+  return (
+    <ParticipantColorsContext.Provider value={{ participants, colorMap, setParticipants }}>
+      {children}
+    </ParticipantColorsContext.Provider>
+  );
+}
+
+export function useParticipantColors() {
+  return useContext(ParticipantColorsContext);
+}
+

--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -1,11 +1,14 @@
 import "@/styles/globals.css";
 import type { AppProps } from "next/app";
 import Layout from "@/components/Layout";
+import { ParticipantColorsProvider } from "@/lib/ParticipantColors";
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
-    <Layout>
-      <Component {...pageProps} />
-    </Layout>
+    <ParticipantColorsProvider>
+      <Layout>
+        <Component {...pageProps} />
+      </Layout>
+    </ParticipantColorsProvider>
   );
 }

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -3,7 +3,9 @@ import { useEffect, useMemo, useState } from "react";
 import { getKPIs, uploadFile, getConflicts } from "@/lib/api";
 import Card from "@/components/Card";
 import Chart from "@/components/Chart";
+import MessageWordBySender from "@/components/MessageWordBySender";
 import useThemePalette from "@/lib/useThemePalette";
+import { useParticipantColors } from "@/lib/ParticipantColors";
 
 type KPI = any;
 const formatNumber = (n: number) => n.toLocaleString();
@@ -24,6 +26,7 @@ export default function Home() {
   const [endDate, setEndDate] = useState<string>("");
   const [zoomRange, setZoomRange] = useState<[number, number] | null>(null);
   const palette = useThemePalette();
+  const { participants, colorMap, setParticipants } = useParticipantColors();
 
   useEffect(() => {
     fetch((process.env.NEXT_PUBLIC_API_BASE||"http://localhost:8000")+"/version")
@@ -39,6 +42,11 @@ export default function Home() {
       setEndDate(days[days.length - 1]);
     }
   }, [kpis]);
+
+  useEffect(() => {
+    const ps = kpis?.participants ?? (kpis?.by_sender?.map((r:any)=>r.sender) ?? []);
+    setParticipants(ps);
+  }, [kpis, setParticipants]);
 
    useEffect(() => {
     setZoomRange(null);
@@ -69,16 +77,6 @@ async function fetchConflicts() {
       setBusy(false);
     }
   };
-
-  const participants: string[] = useMemo(() => kpis?.participants ?? (kpis?.by_sender?.map((r:any)=>r.sender) ?? []), [kpis]);
-
-  const colorMap = useMemo(() => {
-    const map: Record<string, string> = {};
-    participants.forEach((p, i) => {
-      map[p] = palette.series[i % palette.series.length];
-    });
-    return map;
-  }, [participants, palette]);
 
   const wordCloudParticipants = participants.slice(0, 2);
   const wordCategories = ["emoji", "swear", "sexual", "space"];
@@ -125,41 +123,6 @@ async function fetchConflicts() {
     setZoomRange([startIdx, endIdx]);
   };
 
-  const messagesOption = () => {
-    const rows = filteredBySender;
-    return {
-      backgroundColor: "transparent",
-      textStyle: { color: palette.text },
-      tooltip: { valueFormatter: (value: number) => formatNumber(value) },
-      xAxis: { type: "category", data: rows.map((r:any)=>r.sender), axisLine:{lineStyle:{color: palette.subtext}}, axisLabel:{color: palette.text} },
-      yAxis: { type: "value", axisLine:{lineStyle:{color: palette.subtext}}, axisLabel:{color: palette.text, formatter: (value:number) => formatNumber(value)} },
-      series: [
-        {
-          type: "bar",
-          data: rows.map((r:any)=>({ value: r.messages, itemStyle: { color: colorMap[r.sender] } })),
-          barWidth: "40%"
-        }
-      ]
-    };
-  };
-
-  const wordsOption = () => {
-    const rows = filteredBySender;
-    return {
-      backgroundColor: "transparent",
-      textStyle: { color: palette.text },
-      tooltip: { valueFormatter: (value: number) => formatNumber(value) },
-      xAxis: { type: "category", data: rows.map((r:any)=>r.sender), axisLine:{lineStyle:{color: palette.subtext}}, axisLabel:{color: palette.text} },
-      yAxis: { type: "value", axisLine:{lineStyle:{color: palette.subtext}}, axisLabel:{color: palette.text, formatter: (value:number) => formatNumber(value)} },
-      series: [
-        {
-          type: "bar",
-          data: rows.map((r:any)=>({ value: r.words, itemStyle: { color: colorMap[r.sender] } })),
-          barWidth: "40%"
-        }
-      ]
-    };
-  };
 
   const replyOption = () => {
     const rs = (kpis?.reply_simple || []) as Array<any>;
@@ -474,14 +437,9 @@ async function fetchConflicts() {
           </section>
 
           <section id="analytics" className="grid grid-cols-1 xl:grid-cols-3 gap-6">
-            <div>
-              <Card title="Messages by sender">
-                <Chart option={messagesOption()} height={260} />
-              </Card>
-            </div>
-            <div>
-              <Card title="Words by sender">
-                <Chart option={wordsOption()} height={260} />
+            <div className="xl:col-span-2">
+              <Card title="Messages & words by sender">
+                <MessageWordBySender rows={filteredBySender} />
               </Card>
             </div>
             <div className="xl:row-span-2">


### PR DESCRIPTION
## Summary
- unify message and word charts into one toggleable component with optional small multiples
- centralize participant color mapping and show legend in top bar
- expose color context across app for consistent chart coloring

## Testing
- `cd web && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689a282cf61c832594bcb53ffacf7292