### PR TITLE
Add conflict timeline strip and card list

### DIFF
--- a/web/components/ConflictCardList.tsx
+++ b/web/components/ConflictCardList.tsx
@@ -1,0 +1,64 @@
+import { useState } from "react";
+
+export interface ConflictItem {
+  date: string;
+  tags?: string[];
+  severity?: number;
+  summary?: string;
+  details?: string;
+}
+
+export default function ConflictCardList({ conflicts, filterDate }: { conflicts: ConflictItem[]; filterDate: string | null; }) {
+  const [open, setOpen] = useState<number | null>(null);
+  const items = filterDate ? conflicts.filter(c => c.date === filterDate) : conflicts;
+
+  if (!items.length) {
+    return <div className="text-sm text-gray-400">No conflicts for selected period.</div>;
+  }
+
+  return (
+    <div className="max-h-[400px] overflow-y-auto space-y-3 pr-2">
+      {items.map((c, idx) => {
+        const expanded = open === idx;
+        return (
+          <div key={idx} className="bg-sub-alt rounded p-3">
+            <div
+              className="flex items-center justify-between cursor-pointer"
+              onClick={() => setOpen(expanded ? null : idx)}
+            >
+              <div className="flex items-center gap-2">
+                <span className="font-mono text-sm">{c.date}</span>
+                <div className="flex flex-wrap gap-1">
+                  {(c.tags || []).map(t => (
+                    <span key={t} className="text-xs px-2 py-0.5 rounded bg-white/10">{t}</span>
+                  ))}
+                </div>
+              </div>
+              <span
+                className="rounded-full flex-shrink-0"
+                style={{
+                  width: 8 + (c.severity || 1) * 4,
+                  height: 8 + (c.severity || 1) * 4,
+                  backgroundColor: severityColor(c.severity)
+                }}
+              />
+            </div>
+            {expanded && (
+              <div className="mt-2 text-sm text-gray-300 whitespace-pre-wrap">
+                {c.details || c.summary}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function severityColor(sev?: number) {
+  if (!sev) return "#6b7280"; // gray-500
+  if (sev >= 4) return "#ef4444"; // red-500
+  if (sev === 3) return "#f97316"; // orange-500
+  if (sev === 2) return "#eab308"; // yellow-500
+  return "#22c55e"; // green-500
+}

--- a/web/components/ConflictTimelineStrip.tsx
+++ b/web/components/ConflictTimelineStrip.tsx
@@ -1,0 +1,39 @@
+import { useState } from "react";
+import type { ConflictItem } from "./ConflictCardList";
+
+export default function ConflictTimelineStrip({ conflicts, onSelectDate }: { conflicts: ConflictItem[]; onSelectDate: (date: string | null) => void; }) {
+  const [selected, setSelected] = useState<string | null>(null);
+  const sorted = conflicts.slice().sort((a, b) => a.date.localeCompare(b.date));
+
+  const handleClick = (date: string) => {
+    const newDate = selected === date ? null : date;
+    setSelected(newDate);
+    onSelectDate(newDate);
+  };
+
+  return (
+    <div className="flex items-center gap-2 overflow-x-auto py-2">
+      {sorted.map((c, idx) => (
+        <button
+          key={idx}
+          title={c.date}
+          onClick={() => handleClick(c.date)}
+          className={`flex-shrink-0 rounded-full ${selected === c.date ? "ring-2 ring-main" : ""}`}
+          style={{
+            width: 8 + (c.severity || 1) * 4,
+            height: 8 + (c.severity || 1) * 4,
+            backgroundColor: severityColor(c.severity)
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+function severityColor(sev?: number) {
+  if (!sev) return "#6b7280";
+  if (sev >= 4) return "#ef4444";
+  if (sev === 3) return "#f97316";
+  if (sev === 2) return "#eab308";
+  return "#22c55e";
+}


### PR DESCRIPTION
## Summary
- Add `ConflictCardList` component for scrolling conflict summaries with severity indicators and expandable details
- Create `ConflictTimelineStrip` to visualize conflicts below the timeline and filter the list on selection
- Integrate strip under the main timeline and place card list in a right-aligned grid section

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a28323c608325a2b1eee1910a3c61