### PR TITLE
feat: synced date range with compare deltas

### DIFF
--- a/web/components/Card.tsx
+++ b/web/components/Card.tsx
@@ -1,13 +1,24 @@
 import { ReactNode } from "react";
 
-export default function Card({ title, children, tooltip }: { title: string; children: ReactNode; tooltip?: string }) {
+export default function Card({
+  title,
+  children,
+  tooltip,
+  badge,
+}: {
+  title: string;
+  children: ReactNode;
+  tooltip?: string;
+  badge?: ReactNode;
+}) {
   return (
     <div
       className="rounded-xl border border-white/10 bg-white/10 p-6 shadow-md backdrop-blur-md"
       title={tooltip}
     >
-      <h2 className="text-sm font-semibold mb-4 text-sub">
+      <h2 className="text-sm font-semibold mb-4 text-sub flex items-center gap-2">
         {title}
+        {badge && <span>{badge}</span>}
       </h2>
       <div>{children}</div>
     </div>

--- a/web/components/Chart.tsx
+++ b/web/components/Chart.tsx
@@ -8,10 +8,29 @@ const ReactECharts = dynamic(async () => {
   return import("echarts-for-react");
 }, { ssr: false });
 
-export default function Chart({ option, height=260, onEvents }: { option: any; height?: number; onEvents?: any }) {
+export default function Chart({ option, height = 260, onEvents = {} }: { option: any; height?: number; onEvents?: any }) {
+  const legendHandler = (params: any, chart: any) => {
+    if (params.event?.event?.altKey) {
+      const names = (chart.getOption().series || []).map((s: any) => s.name);
+      const selected: Record<string, boolean> = {};
+      names.forEach((n: string) => {
+        selected[n] = n === params.name;
+      });
+      chart.setOption({ legend: { selected } });
+    }
+  };
+
+  const mergedEvents = {
+    ...onEvents,
+    legendselectchanged: (p: any, c: any) => {
+      legendHandler(p, c);
+      if (onEvents.legendselectchanged) onEvents.legendselectchanged(p, c);
+    },
+  };
+
   return (
     <div className="w-full">
-      <ReactECharts option={option} style={{ height }} notMerge={true} lazyUpdate={true} onEvents={onEvents} />
+      <ReactECharts option={option} style={{ height }} notMerge={true} lazyUpdate={true} onEvents={mergedEvents} />
     </div>
   );
 }

--- a/web/components/DeltaBadge.tsx
+++ b/web/components/DeltaBadge.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+export default function DeltaBadge({ value }: { value: number }) {
+  const color = value > 0 ? "text-green-400" : value < 0 ? "text-red-400" : "text-gray-400";
+  const sign = value > 0 ? "+" : "";
+  return <span className={`text-xs ${color}`}>{sign}{value.toLocaleString()}</span>;
+}


### PR DESCRIPTION
## Summary
- sync timeline brush with date range inputs to share a single source of truth
- allow Alt-clicking chart legends to solo a series
- add optional compare mode that shows delta badges for messages and words

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a28403d548325a0354f22bef9914b