### PR TITLE
Refactor dashboard to 12-column grid layout

### DIFF
--- a/web/components/Layout.tsx
+++ b/web/components/Layout.tsx
@@ -24,7 +24,7 @@ export default function Layout({ children }: { children: ReactNode }) {
         </header>
         <div className="flex relative z-10">
           <Sidebar />
-          <main className="flex-1 p-6 space-y-6">
+          <main className="flex-1 p-6 grid grid-cols-12 gap-6">
             {children}
           </main>
         </div>


### PR DESCRIPTION
## Summary
- Rework main layout to use a responsive 12-column grid
- Restructure index page into top bar, KPI strip, timeline, participation/tone, heatmap, and profanity-affection/conflict sections

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689a28498d2483259b701af1bc2430f2