### PR TITLE
feat: show per-person message timeline

### DIFF
--- a/web/components/UnifiedTimeline.tsx
+++ b/web/components/UnifiedTimeline.tsx
@@ -2,98 +2,49 @@ import { useMemo } from "react";
 import Chart from "@/components/Chart";
 import useThemePalette from "@/lib/useThemePalette";
 
-interface MessagePoint { day: string; messages: number; }
-interface WordPoint { day: string; words: number; }
-interface ConflictMarker { date: string; summary?: string; }
-interface AffectionPoint { day: string; affection: number; }
+interface MessagePoint { day: string; sender: string; messages: number; }
 
 interface Props {
   messages: MessagePoint[];
-  words: WordPoint[];
-  conflicts?: ConflictMarker[];
-  affection?: AffectionPoint[];
   startDate?: string;
   endDate?: string;
   onRangeChange?: (start: string, end: string) => void;
 }
 
-export default function UnifiedTimeline({
-  messages,
-  words,
-  conflicts = [],
-  affection = [],
-  startDate,
-  endDate,
-  onRangeChange,
-}: Props) {
+export default function UnifiedTimeline({ messages, startDate, endDate, onRangeChange }: Props) {
   const palette = useThemePalette();
 
   const days = useMemo(() => {
-    const s = new Set<string>();
-    messages.forEach((r) => s.add(r.day));
-    words.forEach((r) => s.add(r.day));
-    return Array.from(s).sort();
-  }, [messages, words]);
-
-  const msgMap = useMemo(() => {
-    const m: Record<string, number> = {};
-    messages.forEach((r) => {
-      m[r.day] = (m[r.day] || 0) + r.messages;
-    });
-    return m;
+    return Array.from(new Set(messages.map(r => r.day))).sort();
   }, [messages]);
 
-  const wordMap = useMemo(() => {
-    const m: Record<string, number> = {};
-    words.forEach((r) => {
-      m[r.day] = (m[r.day] || 0) + r.words;
-    });
-    return m;
-  }, [words]);
+  const senders = useMemo(() => {
+    return Array.from(new Set(messages.map(r => r.sender)));
+  }, [messages]);
 
-  const msgData = days.map((d) => msgMap[d] || 0);
-  const wordData = days.map((d) => wordMap[d] || 0);
+  const dataMap = useMemo(() => {
+    const map: Record<string, Record<string, number>> = {};
+    messages.forEach(r => {
+      if (!map[r.day]) map[r.day] = {};
+      map[r.day][r.sender] = r.messages;
+    });
+    return map;
+  }, [messages]);
+
+  const series = senders.map((s, i) => ({
+    name: s,
+    type: "line",
+    smooth: true,
+    lineStyle: { width: 2 },
+    itemStyle: { color: palette.series[i % palette.series.length] },
+    data: days.map(d => (dataMap[d] && dataMap[d][s]) || 0),
+  }));
 
   const startIdx = startDate ? days.indexOf(startDate) : 0;
   const endIdx = endDate ? days.indexOf(endDate) : days.length - 1;
   const len = Math.max(1, days.length - 1);
   const startPercent = startIdx >= 0 ? (startIdx / len) * 100 : 0;
   const endPercent = endIdx >= 0 ? (endIdx / len) * 100 : 100;
-
-  const markerSeries: any[] = [];
-  if (conflicts.length) {
-    markerSeries.push({
-      name: "Conflicts",
-      type: "scatter",
-      symbol: "triangle",
-      symbolSize: 12,
-      data: conflicts.map((c) => ({
-        value: [c.date, (msgMap[c.date] || 0) + (wordMap[c.date] || 0)],
-        date: c.date,
-        summary: c.summary,
-      })),
-      itemStyle: { color: palette.series[2] },
-      tooltip: { formatter: (p: any) => `${p.data.date}<br/>${p.data.summary || ""}` },
-    });
-  }
-  if (affection.length) {
-    const aff = affection.filter((a) => a.affection > 0);
-    markerSeries.push({
-      name: "Affection",
-      type: "scatter",
-      symbol: "circle",
-      symbolSize: 10,
-      data: aff.map((a) => ({
-        value: [a.day, (msgMap[a.day] || 0) + (wordMap[a.day] || 0)],
-        day: a.day,
-        affection: a.affection,
-      })),
-      itemStyle: { color: palette.series[3] },
-      tooltip: {
-        formatter: (p: any) => `${p.data.day}<br/>Affection: ${p.data.affection}`,
-      },
-    });
-  }
 
   const option = {
     backgroundColor: "transparent",
@@ -102,7 +53,7 @@ export default function UnifiedTimeline({
       trigger: "axis",
       valueFormatter: (v: number) => v.toLocaleString(),
     },
-    legend: { data: ["Messages", "Words"], textStyle: { color: palette.text } },
+    legend: { data: senders, textStyle: { color: palette.text } },
     xAxis: {
       type: "category",
       data: days,
@@ -121,23 +72,7 @@ export default function UnifiedTimeline({
       { type: "inside", start: startPercent, end: endPercent },
       { type: "slider", start: startPercent, end: endPercent },
     ],
-    series: [
-      {
-        name: "Messages",
-        type: "bar",
-        stack: "total",
-        data: msgData,
-        itemStyle: { color: palette.series[0] },
-      },
-      {
-        name: "Words",
-        type: "bar",
-        stack: "total",
-        data: wordData,
-        itemStyle: { color: palette.series[1] },
-      },
-      ...markerSeries,
-    ],
+    series,
   };
 
   const handleZoom = (e: any) => {

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -99,15 +99,6 @@ async function fetchConflicts() {
     return participants.map(p => ({ sender: p, messages: msgMap[p]||0, words: wordMap[p]||0 }));
   }, [kpis, startDate, endDate, participants]);
 
-  const conflictMarkers = useMemo(
-    () => conflicts.flatMap(p => (p.conflicts || []).map((c:any) => ({ date: c.date, summary: c.summary }))),
-    [conflicts]
-  );
-  const affectionMarkers = useMemo(
-    () => (kpis?.timeline_affection || []) as Array<{day:string; affection:number}>,
-    [kpis]
-  );
-
   const messagesOption = () => {
     const rows = filteredBySender;
     return {
@@ -363,9 +354,6 @@ async function fetchConflicts() {
               <Card title="Timeline">
                 <UnifiedTimeline
                   messages={kpis.timeline_messages || []}
-                  words={kpis.timeline_words || []}
-                  conflicts={conflictMarkers}
-                  affection={affectionMarkers}
                   startDate={startDate}
                   endDate={endDate}
                   onRangeChange={(s, e) => { setStartDate(s); setEndDate(e); }}


### PR DESCRIPTION
## Summary
- Remove conflict markers from main timeline
- Render timeline as a per-person line chart

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b3e81ac8883258d3343baa1e55529