### PR TITLE
Fix bubble size scaling for words per message

### DIFF
--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -173,13 +173,13 @@ async function fetchConflicts() {
       sender: r.sender,
       messagesPerDay: r.messages / days,
       wordsPerDay: r.words / days,
-      mpw: r.words ? r.messages / r.words : 0
+      wpm: r.messages ? r.words / r.messages : 0
     }));
     return {
       backgroundColor: "transparent",
       textStyle: { color: palette.text },
       tooltip: {
-        formatter: (p: any) => `${p.data.sender}<br/>Messages/day: ${p.data.messagesPerDay.toFixed(2)}<br/>Words/day: ${p.data.wordsPerDay.toFixed(2)}<br/>Msgs/word: ${p.data.mpw.toFixed(2)}`
+        formatter: (p: any) => `${p.data.sender}<br/>Messages/day: ${p.data.messagesPerDay.toFixed(2)}<br/>Words/day: ${p.data.wordsPerDay.toFixed(2)}<br/>Words/msg: ${p.data.wpm.toFixed(2)}`
       },
       xAxis: {
         type: "value",
@@ -201,8 +201,8 @@ async function fetchConflicts() {
             sender: r.sender,
             messagesPerDay: r.messagesPerDay,
             wordsPerDay: r.wordsPerDay,
-            mpw: r.mpw,
-            symbolSize: Math.max(20, Math.min(80, r.mpw * 200)),
+            wpm: r.wpm,
+            symbolSize: Math.max(20, Math.min(80, r.wpm * 8)),
             itemStyle: { color: colorMap[r.sender] }
           })),
           label: { show: true, formatter: (p:any) => p.data.sender, color: palette.text }


### PR DESCRIPTION
## Summary
- adjust messages vs. words chart to size bubbles by words per message
- update tooltip wording to reflect words/message metric

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b3eb1e84083259998f0279e491e32