### PR TITLE
Add sender share and distribution charts

### DIFF
--- a/web/components/DailyRhythmHeatmap.tsx
+++ b/web/components/DailyRhythmHeatmap.tsx
@@ -1,0 +1,56 @@
+import { useMemo, useState } from "react";
+import Chart from "@/components/Chart";
+import Card from "@/components/Card";
+import useThemePalette from "@/lib/useThemePalette";
+
+interface HeatPoint {
+  weekday: number; // 0=Mon
+  hour: number;
+  count: number;
+  sender: string;
+}
+
+interface Props {
+  data: HeatPoint[];
+  participants: string[];
+}
+
+export default function DailyRhythmHeatmap({ data, participants }: Props) {
+  const palette = useThemePalette();
+  const [person, setPerson] = useState<string>("All");
+
+  const filtered = useMemo(() => {
+    return data.filter(d => person === "All" || d.sender === person);
+  }, [data, person]);
+
+  const hours = Array.from({ length: 24 }).map((_, i) => i);
+  const weekdays = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+  const mat = Array.from({ length: 7 }, () => Array(24).fill(0));
+  filtered.forEach(r => { mat[r.weekday][r.hour] += r.count; });
+  const chartData: any[] = [];
+  for (let w = 0; w < 7; w++) for (let h = 0; h < 24; h++) chartData.push([h, w, mat[w][h]]);
+  const vmax = Math.max(1, ...chartData.map(d => d[2]));
+
+  const option = {
+    backgroundColor: "transparent",
+    textStyle: { color: palette.text },
+    tooltip: { valueFormatter: (v: number) => v.toLocaleString() },
+    xAxis: { type: "category", data: hours, axisLabel: { color: palette.text }, axisLine: { lineStyle: { color: palette.subtext } } },
+    yAxis: { type: "category", data: weekdays, axisLabel: { color: palette.text }, axisLine: { lineStyle: { color: palette.subtext } } },
+    visualMap: { min: 0, max: vmax, calculable: true, orient: "horizontal", left: "center", textStyle: { color: palette.text }, inRange: { color: [palette.series[0], palette.series[1], palette.series[5]] } },
+    series: [{ type: "heatmap", data: chartData, label: { show: false } }]
+  };
+
+  return (
+    <Card title="Daily rhythm heatmap (weekday × hour)">
+      <div className="flex gap-2 mb-2">
+        <button onClick={() => setPerson("All")} className={`px-3 py-1 rounded-full ${person === "All" ? "bg-white/20" : "bg-white/10"}`}>All</button>
+        {participants.map(p => (
+          <button key={p} onClick={() => setPerson(p)} className={`px-3 py-1 rounded-full ${person === p ? "bg-white/20" : "bg-white/10"}`}>{p}</button>
+        ))}
+      </div>
+      <Chart option={option} height={360} />
+    </Card>
+  );
+}
+

--- a/web/components/ReplyTimeDistribution.tsx
+++ b/web/components/ReplyTimeDistribution.tsx
@@ -1,0 +1,71 @@
+import { useMemo } from "react";
+import Chart from "@/components/Chart";
+import Card from "@/components/Card";
+import useThemePalette from "@/lib/useThemePalette";
+
+interface Props {
+  data: Record<string, number[]>; // sender -> reply times in seconds
+}
+
+function calcBox(values: number[]): [number, number, number, number, number] {
+  if (!values.length) return [0, 0, 0, 0, 0];
+  const v = [...values].sort((a, b) => a - b);
+  const q = (p: number) => {
+    const idx = (v.length - 1) * p;
+    const lo = Math.floor(idx);
+    const hi = Math.ceil(idx);
+    if (lo === hi) return v[lo];
+    return v[lo] * (hi - idx) + v[hi] * (idx - lo);
+  };
+  return [v[0], q(0.25), q(0.5), q(0.75), v[v.length - 1]];
+}
+
+export default function ReplyTimeDistribution({ data }: Props) {
+  const palette = useThemePalette();
+  const participants = useMemo(() => Object.keys(data), [data]);
+
+  const colorMap = useMemo(() => {
+    const map: Record<string, string> = {};
+    participants.forEach((p, i) => {
+      map[p] = palette.series[i % palette.series.length];
+    });
+    return map;
+  }, [participants, palette]);
+
+  const seriesData = participants.map(p => ({
+    name: p,
+    value: calcBox(data[p] || []),
+    itemStyle: { color: colorMap[p] }
+  }));
+
+  const option = {
+    backgroundColor: "transparent",
+    textStyle: { color: palette.text },
+    tooltip: {
+      formatter: (p: any) => {
+        const v = p.data.value;
+        return `${p.name}<br/>Min: ${v[0]}s<br/>Q1: ${v[1]}s<br/>Median: ${v[2]}s<br/>Q3: ${v[3]}s<br/>Max: ${v[4]}s`;
+      }
+    },
+    xAxis: {
+      type: "category",
+      data: participants,
+      axisLabel: { color: palette.text },
+      axisLine: { lineStyle: { color: palette.subtext } }
+    },
+    yAxis: {
+      type: "value",
+      name: "Seconds",
+      axisLabel: { color: palette.text },
+      axisLine: { lineStyle: { color: palette.subtext } }
+    },
+    series: [{ type: "boxplot", data: seriesData }]
+  };
+
+  return (
+    <Card title="Reply time distribution">
+      <Chart option={option} height={260} />
+    </Card>
+  );
+}
+

--- a/web/components/SenderShareAreaChart.tsx
+++ b/web/components/SenderShareAreaChart.tsx
@@ -1,0 +1,95 @@
+import { useMemo } from "react";
+import Chart from "@/components/Chart";
+import Card from "@/components/Card";
+import useThemePalette from "@/lib/useThemePalette";
+
+interface MessagePoint {
+  day: string;
+  sender: string;
+  messages: number;
+}
+
+interface Props {
+  messages: MessagePoint[];
+  participants: string[];
+}
+
+function weekKey(day: string): string {
+  const d = new Date(day);
+  // Adjust to Monday as start of week
+  const diff = (d.getUTCDay() + 6) % 7;
+  const monday = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() - diff));
+  return monday.toISOString().slice(0, 10);
+}
+
+export default function SenderShareAreaChart({ messages, participants }: Props) {
+  const palette = useThemePalette();
+
+  const colorMap = useMemo(() => {
+    const map: Record<string, string> = {};
+    participants.forEach((p, i) => {
+      map[p] = palette.series[i % palette.series.length];
+    });
+    return map;
+  }, [participants, palette]);
+
+  const weeks = useMemo(() => {
+    const weekSet = new Set<string>();
+    messages.forEach(m => weekSet.add(weekKey(m.day)));
+    return Array.from(weekSet).sort();
+  }, [messages]);
+
+  const dataMap = useMemo(() => {
+    const map: Record<string, Record<string, number>> = {};
+    messages.forEach(m => {
+      const w = weekKey(m.day);
+      if (!map[w]) map[w] = {};
+      map[w][m.sender] = (map[w][m.sender] || 0) + m.messages;
+    });
+    return map;
+  }, [messages]);
+
+  const series = participants.map((p, i) => ({
+    name: p,
+    type: "line",
+    stack: "share",
+    areaStyle: {},
+    lineStyle: { width: 1 },
+    itemStyle: { color: colorMap[p] },
+    data: weeks.map(w => {
+      const total = participants.reduce((s, pp) => s + (dataMap[w]?.[pp] || 0), 0);
+      const val = total ? ((dataMap[w]?.[p] || 0) / total) * 100 : 0;
+      return Number(val.toFixed(2));
+    })
+  }));
+
+  const option = {
+    backgroundColor: "transparent",
+    textStyle: { color: palette.text },
+    tooltip: {
+      trigger: "axis",
+      valueFormatter: (v: number) => `${v.toFixed(1)}%`
+    },
+    legend: { data: participants, textStyle: { color: palette.text } },
+    xAxis: {
+      type: "category",
+      data: weeks,
+      axisLabel: { color: palette.text },
+      axisLine: { lineStyle: { color: palette.subtext } }
+    },
+    yAxis: {
+      type: "value",
+      max: 100,
+      axisLabel: { color: palette.text, formatter: (v: number) => `${v}%` },
+      axisLine: { lineStyle: { color: palette.subtext } }
+    },
+    series
+  };
+
+  return (
+    <Card title="Sender share over time">
+      <Chart option={option} height={260} />
+    </Card>
+  );
+}
+

--- a/web/components/WordsPerMessageBoxplot.tsx
+++ b/web/components/WordsPerMessageBoxplot.tsx
@@ -1,0 +1,71 @@
+import { useMemo } from "react";
+import Chart from "@/components/Chart";
+import Card from "@/components/Card";
+import useThemePalette from "@/lib/useThemePalette";
+
+interface Props {
+  data: Record<string, number[]>; // sender -> word counts per message
+}
+
+function calcBox(values: number[]): [number, number, number, number, number] {
+  if (!values.length) return [0, 0, 0, 0, 0];
+  const v = [...values].sort((a, b) => a - b);
+  const q = (p: number) => {
+    const idx = (v.length - 1) * p;
+    const lo = Math.floor(idx);
+    const hi = Math.ceil(idx);
+    if (lo === hi) return v[lo];
+    return v[lo] * (hi - idx) + v[hi] * (idx - lo);
+  };
+  return [v[0], q(0.25), q(0.5), q(0.75), v[v.length - 1]];
+}
+
+export default function WordsPerMessageBoxplot({ data }: Props) {
+  const palette = useThemePalette();
+  const participants = useMemo(() => Object.keys(data), [data]);
+
+  const colorMap = useMemo(() => {
+    const map: Record<string, string> = {};
+    participants.forEach((p, i) => {
+      map[p] = palette.series[i % palette.series.length];
+    });
+    return map;
+  }, [participants, palette]);
+
+  const seriesData = participants.map(p => ({
+    name: p,
+    value: calcBox(data[p] || []),
+    itemStyle: { color: colorMap[p] }
+  }));
+
+  const option = {
+    backgroundColor: "transparent",
+    textStyle: { color: palette.text },
+    tooltip: {
+      formatter: (p: any) => {
+        const v = p.data.value;
+        return `${p.name}<br/>Min: ${v[0]}<br/>Q1: ${v[1]}<br/>Median: ${v[2]}<br/>Q3: ${v[3]}<br/>Max: ${v[4]}`;
+      }
+    },
+    xAxis: {
+      type: "category",
+      data: participants,
+      axisLabel: { color: palette.text },
+      axisLine: { lineStyle: { color: palette.subtext } }
+    },
+    yAxis: {
+      type: "value",
+      name: "Words",
+      axisLabel: { color: palette.text },
+      axisLine: { lineStyle: { color: palette.subtext } }
+    },
+    series: [{ type: "boxplot", data: seriesData }]
+  };
+
+  return (
+    <Card title="Words per message distribution">
+      <Chart option={option} height={260} />
+    </Card>
+  );
+}
+


### PR DESCRIPTION
## Summary
- Add reusable components for sender share area chart, words-per-message boxplot, reply-time boxplot, and daily rhythm heatmap
- Replace analytics section with left-column panel using new visualizations

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b43f8c8208325a239b3274c34374f