### PR TITLE
Expose reply time and words-per-message distributions

### DIFF
--- a/services/api/kpis.py
+++ b/services/api/kpis.py
@@ -202,12 +202,20 @@ def compute(df: pd.DataFrame) -> Dict[str, Any]:
         "words": int(by_sender_df["words"].sum()) if len(by_sender_df)>0 else 0
     }
 
+    # Words per message distribution per participant
+    words_per_message = {
+        str(p): d[d["sender"] == p]["n_words"].astype(int).tolist()
+        for p in participants
+    }
+
     # Reply stats (first message in each run versus next sender)
     rp = reply_pairs(d)
     reply_simple = []
+    reply_times = {str(p): [] for p in participants}
     if not rp.empty:
         for person, arr in rp.groupby("to")["sec"]:
             arr = arr.clip(lower=0)
+            reply_times[str(person)] = arr.astype(float).tolist()
             reply_simple.append({
                 "person": str(person),
                 "seconds": float(arr.mean()),
@@ -288,6 +296,8 @@ def compute(df: pd.DataFrame) -> Dict[str, Any]:
         "by_sender": by_sender_df.to_dict(orient="records"),
         "totals": totals,
         "reply_simple": reply_simple,
+        "words_per_message": words_per_message,
+        "reply_times": reply_times,
         "interruptions": interrupts.to_dict(orient="records"),
         "questions": {"total": questions_total, "unanswered_15m": unanswered_total},
         "questions_split": q_split,

--- a/services/api/test_distributions.py
+++ b/services/api/test_distributions.py
@@ -1,0 +1,17 @@
+import pytest
+from parse import parse_export
+from kpis import to_df, compute
+
+sample_chat = """2024-01-01, 9:00 a.m. - Alice: hi
+2024-01-01, 9:01 a.m. - Bob: hey there
+2024-01-01, 9:02 a.m. - Alice: how are you?
+2024-01-01, 9:05 a.m. - Bob: good"""
+
+def test_words_and_reply_distributions():
+    msgs = parse_export(sample_chat)
+    df = to_df(msgs)
+    k = compute(df)
+    assert k["words_per_message"]["Alice"] == [1, 3]
+    assert k["words_per_message"]["Bob"] == [2, 1]
+    assert sorted(k["reply_times"]["Bob"]) == [60.0, 180.0]
+    assert sorted(k["reply_times"]["Alice"]) == [60.0]


### PR DESCRIPTION
## Summary
- compute per-person words-per-message distribution in KPI payload
- compute full reply time lists alongside average metrics
- test distributions for words and reply times

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689b4b97bd98832599d7928c769013fd