### PR TITLE
feat: refine heatmap layout

### DIFF
--- a/web/components/DailyRhythmHeatmap.tsx
+++ b/web/components/DailyRhythmHeatmap.tsx
@@ -35,10 +35,50 @@ export default function DailyRhythmHeatmap({ data, participants }: Props) {
     backgroundColor: "transparent",
     textStyle: { color: palette.text },
     tooltip: { valueFormatter: (v: number) => v.toLocaleString() },
-    xAxis: { type: "category", data: hours, axisLabel: { color: palette.text }, axisLine: { lineStyle: { color: palette.subtext } } },
-    yAxis: { type: "category", data: weekdays, axisLabel: { color: palette.text }, axisLine: { lineStyle: { color: palette.subtext } } },
-    visualMap: { min: 0, max: vmax, calculable: true, orient: "horizontal", left: "center", textStyle: { color: palette.text }, inRange: { color: [palette.series[0], palette.series[1], palette.series[5]] } },
-    series: [{ type: "heatmap", data: chartData, label: { show: false } }]
+    xAxis: {
+      type: "category",
+      data: hours,
+      position: "top",
+      axisLabel: { color: palette.text },
+      axisLine: { lineStyle: { color: palette.subtext } }
+    },
+    yAxis: {
+      type: "category",
+      data: weekdays,
+      axisLabel: { color: palette.text },
+      axisLine: { lineStyle: { color: palette.subtext } }
+    },
+    visualMap: {
+      min: 0,
+      max: vmax,
+      orient: "horizontal",
+      left: "center",
+      textStyle: { color: palette.text },
+      inRange: { color: [palette.series[0]], colorAlpha: [0, 1] }
+    },
+    series: [
+      {
+        type: "custom",
+        silent: true,
+        data: [[5], [6]],
+        renderItem: (params: any, api: any) => {
+          const y = api.value(0);
+          const start = api.coord([0, y]);
+          const end = api.coord([24, y + 1]);
+          return {
+            type: "rect",
+            shape: {
+              x: start[0],
+              y: start[1],
+              width: end[0] - start[0],
+              height: end[1] - start[1]
+            },
+            style: { fill: palette.text, opacity: 0.05 }
+          };
+        }
+      },
+      { type: "heatmap", data: chartData, label: { show: false }, z: 1 }
+    ]
   };
 
   return (


### PR DESCRIPTION
## Summary
- add single color scale bar for message counts
- highlight weekends and move hour labels to top axis

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689dfb7244548325ac99e28afeadc539