### PR TITLE
Normalize and validate daily theme results

### DIFF
--- a/services/api/daily_themes.py
+++ b/services/api/daily_themes.py
@@ -8,6 +8,11 @@ from typing import Any, Dict, List
 from openai import OpenAI
 
 from parse import Message
+from themes import THEMES, mood_to_color
+
+
+class DailyThemesError(ValueError):
+    """Raised when the model returns malformed daily theme data."""
 
 PROMPT_TEMPLATE = (
     "You are an assistant categorizing daily conversation themes.\n"
@@ -51,8 +56,69 @@ def analyze_range(
         model="gpt-5-nano", input=prompt, response_format={"type": "json_object"}
     )
     content = (resp.output_text or "").strip()
+    return parse_days_json(content, start, end, tz)
+
+
+def parse_days_json(content: str, start: dt.date, end: dt.date, tz: dt.tzinfo) -> Dict[str, Any]:
+    """Parse the model JSON output for a 14-day range.
+
+    Parameters
+    ----------
+    content:
+        Raw JSON string returned by the model.
+    start, end:
+        Start and end dates of the 14-day range.
+    tz:
+        Timezone used for analysis.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Structured dictionary with days sorted chronologically and range info.
+
+    Raises
+    ------
+    DailyThemesError
+        If the JSON is malformed or contains invalid theme identifiers.
+    """
+
     try:
-        data = json.loads(content)
-    except json.JSONDecodeError:
-        data = {}
-    return data
+        raw = json.loads(content)
+    except json.JSONDecodeError as exc:
+        raise DailyThemesError(f"Malformed JSON: {exc.msg}") from exc
+
+    if not isinstance(raw, dict):
+        raise DailyThemesError("Top-level JSON must be an object mapping dates")
+
+    days: List[Dict[str, Any]] = []
+    for date_str, info in raw.items():
+        if not isinstance(info, dict):
+            raise DailyThemesError(f"Day entry for {date_str} must be an object")
+
+        # Normalize mood color
+        mood_pct = (
+            info.get("mood_pct")
+            or info.get("mood_percent")
+            or info.get("mood")
+            or 0
+        )
+        info["color_hex"] = mood_to_color(int(mood_pct))
+
+        dom = info.get("dominant_theme")
+        if isinstance(dom, dict):
+            dom_id = dom.get("id")
+            if dom_id not in THEMES:
+                raise DailyThemesError(f"Unknown theme id {dom_id} for {date_str}")
+            dom.update(THEMES[dom_id])
+            info["dominant_theme"] = dom
+
+        days.append({"date": date_str, **info})
+
+    days.sort(key=lambda d: d["date"])
+
+    return {
+        "range_start": start.isoformat(),
+        "range_end": end.isoformat(),
+        "timezone": str(tz),
+        "days": days,
+    }

--- a/services/api/test_daily_themes.py
+++ b/services/api/test_daily_themes.py
@@ -1,0 +1,43 @@
+import datetime as dt
+import pytest
+
+from daily_themes import parse_days_json, DailyThemesError
+from themes import THEMES, mood_to_color
+
+
+valid_json = (
+    """
+    {
+      "2024-01-02": {"mood": 75, "color_hex": "#fff", "dominant_theme": {"id": 2}},
+      "2024-01-01": {"mood": 20, "color_hex": "#000", "dominant_theme": {"id": 4}}
+    }
+    """.strip()
+)
+
+
+def test_parse_days_json_normalizes_and_sorts():
+    start = dt.date(2024, 1, 1)
+    end = dt.date(2024, 1, 2)
+    tz = dt.timezone.utc
+    out = parse_days_json(valid_json, start, end, tz)
+    assert out["range_start"] == "2024-01-01"
+    assert out["range_end"] == "2024-01-02"
+    assert out["timezone"] == "UTC"
+    dates = [d["date"] for d in out["days"]]
+    assert dates == ["2024-01-01", "2024-01-02"]
+    first, second = out["days"]
+    assert first["color_hex"] == mood_to_color(20)
+    assert second["color_hex"] == mood_to_color(75)
+    assert first["dominant_theme"]["name"] == THEMES[4]["name"]
+    assert second["dominant_theme"]["icon"] == THEMES[2]["icon"]
+
+
+def test_parse_days_json_bad_json_raises():
+    with pytest.raises(DailyThemesError):
+        parse_days_json('{bad json', dt.date(2024, 1, 1), dt.date(2024, 1, 2), dt.timezone.utc)
+
+
+def test_parse_days_json_unknown_theme():
+    bad_theme_json = '{"2024-01-01": {"mood": 10, "dominant_theme": {"id": 99}}}'
+    with pytest.raises(DailyThemesError):
+        parse_days_json(bad_theme_json, dt.date(2024, 1, 1), dt.date(2024, 1, 1), dt.timezone.utc)


### PR DESCRIPTION
## Summary
- Ensure daily theme responses are fully normalized with corrected mood colors and theme metadata
- Add strict JSON parsing with structured errors for malformed or unknown theme IDs
- Test parsing logic for sorting, color buckets, and error handling

## Testing
- `pytest services/api/test_daily_themes.py -q`
- `pytest services/api -q`


------
https://chatgpt.com/codex/tasks/task_e_689e33846dc8832583559b53df1aee84