### PR TITLE
feat: add daily themes endpoint

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -5,3 +5,4 @@ pydantic==2.7.4
 numpy==1.26.4
 pandas==2.2.2
 python-multipart==0.0.9
+openai>=1.0.0


### PR DESCRIPTION
## Summary
- add `/daily_themes` endpoint for analyzing uploaded chats by day
- support timezone, start, and end filters
- include OpenAI dependency

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e36c272208325ad3baec986245638