### PR TITLE
Add daily themes component and page

### DIFF
--- a/web/components/DailyThemes.tsx
+++ b/web/components/DailyThemes.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react";
+import Card from "@/components/Card";
+import { API_BASE } from "@/lib/api";
+
+interface DayTheme {
+  date: string;
+  summary?: string;
+  mood?: number;
+  mood_pct?: number;
+  color_hex: string;
+  dominant_theme?: { id: number; name: string; icon: string };
+}
+
+export default function DailyThemes() {
+  const [days, setDays] = useState<DayTheme[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch(`${API_BASE}/daily_themes`)
+      .then((res) => {
+        if (!res.ok) throw new Error("Failed to load daily themes");
+        return res.json();
+      })
+      .then((data) => setDays(data.days || []))
+      .catch((err) => setError(err.message));
+  }, []);
+
+  if (error) return <div className="text-red-400">{error}</div>;
+  if (!days.length) return <div className="text-gray-300">No daily themes yet.</div>;
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      {days.map((day) => (
+        <Card key={day.date} title={day.date}>
+          <div className="flex items-center mb-2">
+            <span className="text-2xl mr-2">{day.dominant_theme?.icon}</span>
+            <span className="flex-1">{day.summary || day.dominant_theme?.name}</span>
+            <span>{(day.mood_pct ?? day.mood ?? 0).toString()}%</span>
+          </div>
+          <div className="h-2 w-full rounded" style={{ backgroundColor: day.color_hex }} />
+        </Card>
+      ))}
+    </div>
+  );
+}
+

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -238,7 +238,10 @@ async function fetchConflicts() {
   return (
     <DateRangeContext.Provider value={{ start: startDate, end: endDate, setRange: updateRange }}>
     <>
-      <div className="flex items-center justify-end">
+      <div className="flex items-center justify-end gap-4">
+        <a href="/themes" className="text-sm text-sub underline">
+          Daily themes
+        </a>
         <label className="px-4 py-2 rounded-xl bg-white/10 hover:bg-white/20 transition cursor-pointer">
           {busy ? "Uploading..." : "Upload chat"}
           <input type="file" className="hidden" accept=".txt" onChange={(e)=>e.target.files&&onUpload(e.target.files[0])} />

--- a/web/pages/themes.tsx
+++ b/web/pages/themes.tsx
@@ -1,0 +1,11 @@
+import DailyThemes from "@/components/DailyThemes";
+
+export default function ThemesPage() {
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold">Daily themes</h2>
+      <DailyThemes />
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add DailyThemes component to retrieve daily theme data and render mood cards
- introduce /themes page and link from dashboard

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e381e4bec83258f51bab99ab2b869