### PR TITLE
Handle missing OpenAI key for daily themes

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI, UploadFile, File, HTTPException, Query
 import datetime as dt
 from zoneinfo import ZoneInfo
 from typing import Optional, List
+import os
 
 from services.api import parse
 from services.api.daily_themes import analyze_range
@@ -66,6 +67,14 @@ async def daily_themes(
     msgs = parse.parse_export(text, tz)
 
     daily = parse.group_by_day(msgs, tz)
+
+    if not os.getenv("OPENAI_API_KEY"):
+        return {
+            "range_start": None,
+            "range_end": None,
+            "timezone": str(tz),
+            "days": [],
+        }
 
     # Apply optional date filters
     if start:

--- a/services/api/main.py
+++ b/services/api/main.py
@@ -82,6 +82,9 @@ async def get_daily_themes():
     """Return daily conversation themes for the uploaded chat."""
     if STATE["messages"] is None:
         raise HTTPException(status_code=404, detail="No upload yet")
+    # Gracefully handle missing model credentials by returning an empty result
+    if not os.getenv("OPENAI_API_KEY"):
+        return {"range_start": None, "range_end": None, "timezone": "UTC", "days": []}
     try:
         daily = group_by_day(STATE["messages"], dt.timezone.utc)
         all_days: List[Dict[str, Any]] = []


### PR DESCRIPTION
## Summary
- Return empty daily themes when OpenAI credentials are absent
- Prevent backend errors by skipping analysis without an API key

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e3dac72708325a5888e605e1f9305