### PR TITLE
Clarify daily theme failure reasons

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -74,6 +74,7 @@ async def daily_themes(
             "range_end": None,
             "timezone": str(tz),
             "days": [],
+            "error": "OpenAI API key not set",
         }
 
     # Apply optional date filters


### PR DESCRIPTION
## Summary
- return explicit error when daily theme analysis lacks an OpenAI API key
- stream error message for missing API key and surface it in the web client
- fall back to non-stream endpoint on stream errors and show server-provided cause

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f498989e883259ecd8d3f19acd983