### PR TITLE
Improve daily themes loading feedback

### DIFF
--- a/web/components/DailyThemes.tsx
+++ b/web/components/DailyThemes.tsx
@@ -25,20 +25,24 @@ export default function DailyThemes({ refreshKey }: DailyThemesProps) {
   const [progress, setProgress] = useState<{ current: number; total: number } | null>(
     null
   );
+  const [loading, setLoading] = useState<boolean>(true);
 
   useEffect(() => {
     setError(null);
     setProgress(null);
     setDays([]);
+    setLoading(true);
     getDailyThemes((current, total) => setProgress({ current, total }))
       .then((d) => {
         setDays(d || []);
         setProgress(null);
       })
       .catch((err) => {
+        console.error("Failed to load daily themes", err);
         setError(err.message);
         setProgress(null);
-      });
+      })
+      .finally(() => setLoading(false));
   }, [refreshKey]);
 
   if (error) return <div className="text-red-400">{error}</div>;
@@ -48,6 +52,7 @@ export default function DailyThemes({ refreshKey }: DailyThemesProps) {
         Analyzing {progress.current}/{progress.total} segments...
       </div>
     );
+  if (loading) return <div className="text-gray-300">Loading daily themes...</div>;
   if (!days.length) return <div className="text-gray-300">No daily themes yet.</div>;
 
   return (

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -75,8 +75,24 @@ export async function getDailyThemes(
     const es = new EventSource(`${API_BASE}/daily_themes_stream`);
     const days: any[] = [];
 
+    const startTimeout = () =>
+      setTimeout(() => {
+        es.close();
+        console.error("Daily themes request timed out");
+        reject(new Error("Daily themes request timed out"));
+      }, 30000);
+
+    let timeout = startTimeout();
+    const reset = () => {
+      clearTimeout(timeout);
+      timeout = startTimeout();
+    };
+    const clear = () => clearTimeout(timeout);
+
     es.onmessage = (ev) => {
+      reset();
       if (ev.data === "[DONE]") {
+        clear();
         es.close();
         days.sort((a, b) => (a.date || "").localeCompare(b.date || ""));
         resolve(days);
@@ -85,7 +101,9 @@ export async function getDailyThemes(
       try {
         const msg = JSON.parse(ev.data);
         if (msg.error) {
+          clear();
           es.close();
+          console.error("Daily themes stream returned error", msg.error);
           reject(new Error(msg.error));
           return;
         }
@@ -103,21 +121,28 @@ export async function getDailyThemes(
         // ignore malformed messages
       }
     };
-    es.onerror = async () => {
+    es.onerror = async (ev) => {
+      console.error("Daily themes stream connection error", ev);
+      clear();
       es.close();
       try {
         const res = await fetch(`${API_BASE}/daily_themes`);
-        const data = await res.json().catch(async () => ({ detail: await res.text() }));
+        const data = await res
+          .json()
+          .catch(async () => ({ detail: await res.text() }));
         if (!res.ok) {
+          console.error("Failed to fetch daily themes after stream error", data);
           reject(new Error(data.detail || "Failed to stream daily themes"));
           return;
         }
         if (data.error) {
+          console.error("Daily themes API returned error", data.error);
           reject(new Error(data.error));
           return;
         }
         resolve(data.days || []);
-      } catch {
+      } catch (err) {
+        console.error("Failed to stream daily themes", err);
         reject(new Error("Failed to stream daily themes"));
       }
     };


### PR DESCRIPTION
## Summary
- show a loading state while daily themes are fetching
- add a timeout and better cleanup for daily theme stream errors
- log daily theme stream failures to surface issues
- reset daily theme request timeout whenever stream messages arrive

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f4bc638808325bfcebc66a68aefca