### PR TITLE
Fix OpenAI daily themes request to use text format

### DIFF
--- a/services/api/daily_themes.py
+++ b/services/api/daily_themes.py
@@ -58,7 +58,9 @@ def analyze_range(
     client = OpenAI(api_key=api_key)
     try:
         resp = client.responses.create(
-            model="gpt-5-nano", input=prompt, response_format={"type": "json_object"}
+            model="gpt-5-nano",
+            input=prompt,
+            text={"format": {"type": "json_object"}},
         )
         content = (resp.output_text or "").strip()
         return parse_days_json(content, start, end, tz)


### PR DESCRIPTION
## Summary
- request JSON output from `client.responses.create` via `text` argument

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f65777354832583a824a30efa2da5