### PR TITLE
Defer daily themes until conflicts finish

### DIFF
--- a/web/components/DailyThemes.tsx
+++ b/web/components/DailyThemes.tsx
@@ -25,9 +25,13 @@ export default function DailyThemes({ refreshKey }: DailyThemesProps) {
   const [progress, setProgress] = useState<{ current: number; total: number } | null>(
     null
   );
-  const [loading, setLoading] = useState<boolean>(true);
+  const [loading, setLoading] = useState<boolean>(false);
 
   useEffect(() => {
+    if (!refreshKey) {
+      setLoading(false);
+      return;
+    }
     setError(null);
     setProgress(null);
     setDays([]);


### PR DESCRIPTION
## Summary
- avoid starting daily theme analysis until explicitly triggered after conflicts

## Testing
- `pytest`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f760336cc832589a53e482c98b440