### PR TITLE
Fix inconsistent hook usage in DailyThemes

### DIFF
--- a/web/components/DailyThemes.tsx
+++ b/web/components/DailyThemes.tsx
@@ -54,16 +54,6 @@ export default function DailyThemes({ refreshKey }: DailyThemesProps) {
       .finally(() => setLoading(false));
   }, [refreshKey]);
 
-  if (error) return <div className="text-red-400">{error}</div>;
-  if (progress)
-    return (
-      <div className="text-gray-400">
-        Analyzing {progress.current}/{progress.total} segments...
-      </div>
-    );
-  if (loading) return <div className="text-gray-300">Loading daily themes...</div>;
-  if (!days.length) return <div className="text-gray-300">No daily themes yet.</div>;
-
   const monthDays = useMemo(() => {
     if (!currentMonth) return new Map<number, DayTheme>();
     const map = new Map<number, DayTheme>();
@@ -94,6 +84,16 @@ export default function DailyThemes({ refreshKey }: DailyThemesProps) {
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
   }, []);
+
+  if (error) return <div className="text-red-400">{error}</div>;
+  if (progress)
+    return (
+      <div className="text-gray-400">
+        Analyzing {progress.current}/{progress.total} segments...
+      </div>
+    );
+  if (loading) return <div className="text-gray-300">Loading daily themes...</div>;
+  if (!days.length) return <div className="text-gray-300">No daily themes yet.</div>;
 
   const monthLabel = currentMonth?.toLocaleDateString(undefined, {
     year: "numeric",


### PR DESCRIPTION
## Summary
- move `useMemo` and `useEffect` calls in `DailyThemes` before conditional early returns
- ensure hooks execute consistently to avoid React error #310

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f80a377708325952325d7914e7705