### PR TITLE
Refine daily theme categories and relationship vibe prompt

### DIFF
--- a/services/api/daily_themes.py
+++ b/services/api/daily_themes.py
@@ -18,12 +18,12 @@ class DailyThemesError(ValueError):
 PROMPT_TEMPLATE = (
     "You are an assistant categorizing daily conversation themes.\n"
     "Given the chat transcript between {date_range} in timezone {timezone},\n"
-    "analyze each day's messages and summarize the prevailing mood.\n"
+    "analyze each day's messages, looking for playfulness and how positively the two are interacting.\n"
+    "Estimate the vibe of their relationship on a scale of 0-100.\n"
     "Return a JSON object mapping each date (YYYY-MM-DD) to an object with:\n"
-    "  mood_pct: integer 0-100 representing overall mood, and\n"
+    "  mood_pct: integer 0-100 representing overall vibe, and\n"
     "  dominant_theme: object {{\"id\": <theme_id>}} where theme_id is one of:\n"
-    "    0 conflict, 1 repair, 2 affection, 3 humor, 4 logistics,\n"
-    "    5 support, 6 celebration, 7 planning, 8 question, 9 other.\n"
+    "    0 normal day, 1 emotional day, 2 conflict day, 3 exciting day.\n"
     "Example: {{\"2024-01-01\": {{\"mood_pct\": 75, \"dominant_theme\": {{\"id\": 2}}}}}}\n"
     "Transcript:\n{transcript}"
 )

--- a/services/api/test_daily_themes.py
+++ b/services/api/test_daily_themes.py
@@ -8,8 +8,8 @@ from themes import THEMES, mood_to_color
 valid_json = (
     """
     {
-      "2024-01-02": {"mood": 75, "color_hex": "#fff", "dominant_theme": {"id": 2}},
-      "2024-01-01": {"mood": 20, "color_hex": "#000", "dominant_theme": {"id": 4}}
+      "2024-01-02": {"mood": 75, "color_hex": "#fff", "dominant_theme": {"id": 3}},
+      "2024-01-01": {"mood": 20, "color_hex": "#000", "dominant_theme": {"id": 0}}
     }
     """.strip()
 )
@@ -28,8 +28,8 @@ def test_parse_days_json_normalizes_and_sorts():
     first, second = out["days"]
     assert first["color_hex"] == mood_to_color(20)
     assert second["color_hex"] == mood_to_color(75)
-    assert first["dominant_theme"]["name"] == THEMES[4]["name"]
-    assert second["dominant_theme"]["icon"] == THEMES[2]["icon"]
+    assert first["dominant_theme"]["name"] == THEMES[0]["name"]
+    assert second["dominant_theme"]["icon"] == THEMES[3]["icon"]
 
 
 def test_parse_days_json_bad_json_raises():

--- a/services/api/themes.py
+++ b/services/api/themes.py
@@ -1,15 +1,8 @@
 """Utilities for theme constants and mood colors.
 
-The module exposes a :data:`THEMES` mapping for the ten high-level
-conversation themes used throughout the project. Each theme is assigned
-an integer identifier, a human readable name and an icon.
-
-Tie-break rule
---------------
-If analysis indicates both *conflict* and *repair* in the same moment,
-conflict takes precedence. Repair is only recorded when it clearly
-supersedes any conflict signal. Downstream consumers rely on this
-convention when reconciling overlapping labels.
+The module exposes a :data:`THEMES` mapping for the daily theme analysis.
+Each theme is assigned an integer identifier, a human readable name and
+an icon.
 """
 
 from __future__ import annotations
@@ -17,16 +10,10 @@ from __future__ import annotations
 from typing import Dict
 
 THEMES: Dict[int, Dict[str, str]] = {
-    0: {"name": "conflict", "icon": "⚔️"},
-    1: {"name": "repair", "icon": "🩹"},
-    2: {"name": "affection", "icon": "❤️"},
-    3: {"name": "humor", "icon": "😂"},
-    4: {"name": "logistics", "icon": "📆"},
-    5: {"name": "support", "icon": "🤗"},
-    6: {"name": "celebration", "icon": "🎉"},
-    7: {"name": "planning", "icon": "📝"},
-    8: {"name": "question", "icon": "❓"},
-    9: {"name": "other", "icon": "💬"},
+    0: {"name": "normal day", "icon": "🙂"},
+    1: {"name": "emotional day", "icon": "😢"},
+    2: {"name": "conflict day", "icon": "⚔️"},
+    3: {"name": "exciting day", "icon": "🎉"},
 }
 
 


### PR DESCRIPTION
## Summary
- simplify daily theme taxonomy to four categories: normal, emotional, conflict, and exciting
- expand daily theme prompt to evaluate playfulness and overall relationship vibe on a 0-100 mood scale
- adjust tests for new theme identifiers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f845f05048325939b795782e6748d