### PR TITLE
Add descriptions for notable daily themes with emoji tooltips

### DIFF
--- a/services/api/test_daily_themes.py
+++ b/services/api/test_daily_themes.py
@@ -8,8 +8,8 @@ from themes import THEMES, mood_to_color
 valid_json = (
     """
     {
-      "2024-01-02": {"mood": 75, "color_hex": "#fff", "dominant_theme": {"id": 3}},
-      "2024-01-01": {"mood": 20, "color_hex": "#000", "dominant_theme": {"id": 0}}
+      "2024-01-02": {"mood": 75, "color_hex": "#fff", "description": "party", "dominant_theme": {"id": 3}},
+      "2024-01-01": {"mood": 20, "color_hex": "#000", "description": "quiet", "dominant_theme": {"id": 0}}
     }
     """.strip()
 )
@@ -28,6 +28,8 @@ def test_parse_days_json_normalizes_and_sorts():
     first, second = out["days"]
     assert first["color_hex"] == mood_to_color(20)
     assert second["color_hex"] == mood_to_color(75)
+    assert first["description"] == "quiet"
+    assert second["description"] == "party"
     assert first["dominant_theme"]["name"] == THEMES[0]["name"]
     assert second["dominant_theme"]["icon"] == THEMES[3]["icon"]
 

--- a/web/components/DailyThemes.tsx
+++ b/web/components/DailyThemes.tsx
@@ -4,7 +4,7 @@ import { getDailyThemes } from "@/lib/api";
 
 interface DayTheme {
   date: string;
-  summary?: string;
+  description?: string;
   mood?: number;
   mood_pct?: number;
   color_hex: string;
@@ -113,11 +113,6 @@ export default function DailyThemes({ refreshKey }: DailyThemesProps) {
         key={d}
         className="relative h-16 rounded-md flex flex-col bg-white/5"
         style={info ? { backgroundColor: info.color_hex } : undefined}
-        title={
-          info
-            ? `${info.dominant_theme?.name || ""} ${(info.mood_pct ?? info.mood ?? 0).toString()}%\n${info.summary || ""}`
-            : undefined
-        }
       >
         <span
           className="text-xs font-bold absolute top-1 left-1 bg-white/80 text-black rounded px-1"
@@ -125,7 +120,10 @@ export default function DailyThemes({ refreshKey }: DailyThemesProps) {
           {d}
         </span>
         {info && (
-          <span className="flex-1 flex items-center justify-center text-xl">
+          <span
+            className="flex-1 flex items-center justify-center text-xl"
+            title={info.description || ""}
+          >
             {info.dominant_theme?.icon}
           </span>
         )}


### PR DESCRIPTION
## Summary
- ask model for brief daily descriptions and only flag emotional/conflict/exciting days when clearly notable
- normalize description field in daily theme parsing and expose it via API
- show emoji tooltips with each day's description in calendar

## Testing
- `pytest`
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689f882703148325b958083086479015