### PR TITLE
feat: speed up daily themes analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ coverage/
 
 # Cache files
 services/api/conflict_cache.json
+services/api/daily_themes_cache.json
 
 # OS / Editors
 .DS_Store

--- a/services/api/test_daily_themes.py
+++ b/services/api/test_daily_themes.py
@@ -77,16 +77,16 @@ def test_daily_themes_stream_initial_progress(monkeypatch):
     from fastapi.testclient import TestClient
 
     monkeypatch.setenv("OPENAI_API_KEY", "test")
-    # Stub out analyze_range to avoid external calls
-    monkeypatch.setattr(
-        "main.analyze_range",
-        lambda *args, **kwargs: {
+    # Stub out stream_daily_themes to avoid external calls
+    async def fake_stream(*args, **kwargs):
+        yield 1, 1, {
             "range_start": "2024-01-01",
             "range_end": "2024-01-01",
             "timezone": "UTC",
             "days": [],
-        },
-    )
+        }
+
+    monkeypatch.setattr("main.stream_daily_themes", fake_stream)
 
     STATE["messages"] = [
         Message(ts=dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc), sender="A", text="hi")

--- a/services/api/test_max_concurrency.py
+++ b/services/api/test_max_concurrency.py
@@ -3,9 +3,10 @@ from pathlib import Path
 
 import asyncio
 import pandas as pd
+import datetime as dt
 
 sys.path.append(str(Path(__file__).resolve().parents[2]))
-from services.api import conflict  # noqa: E402
+from services.api import conflict, daily_themes  # noqa: E402
 
 
 async def _dummy_analyze(period, sub, client, model, sem):
@@ -56,6 +57,62 @@ def test_stream_conflicts_respects_parameter(monkeypatch):
 
     async def run():
         async for _ in conflict.stream_conflicts(df, max_concurrency=3):
+            pass
+
+    asyncio.run(run())
+
+    assert recorded["value"] == 3
+
+
+async def _dummy_daily(start, end, msgs, tz, sem):
+    return {
+        "range_start": start.isoformat(),
+        "range_end": end.isoformat(),
+        "timezone": str(tz),
+        "days": [],
+    }
+
+
+def _make_ranges():
+    return [(dt.date(2024, 1, 1), dt.date(2024, 1, 14), [])]
+
+
+def test_analyze_ranges_uses_default_concurrency(monkeypatch):
+    ranges = _make_ranges()
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    monkeypatch.setattr(daily_themes, "_analyze_range_async", _dummy_daily)
+    monkeypatch.setattr(daily_themes, "DEFAULT_MAX_CONCURRENCY", 7)
+
+    recorded = {}
+
+    class DummySem:
+        def __init__(self, value):
+            recorded["value"] = value
+
+    monkeypatch.setattr(asyncio, "Semaphore", DummySem)
+
+    asyncio.run(daily_themes.analyze_ranges(ranges, dt.timezone.utc))
+
+    assert recorded["value"] == 7
+
+
+def test_stream_daily_themes_respects_parameter(monkeypatch):
+    ranges = _make_ranges()
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    monkeypatch.setattr(daily_themes, "_analyze_range_async", _dummy_daily)
+
+    recorded = {}
+
+    class DummySem:
+        def __init__(self, value):
+            recorded["value"] = value
+
+    monkeypatch.setattr(asyncio, "Semaphore", DummySem)
+
+    async def run():
+        async for _ in daily_themes.stream_daily_themes(
+            ranges, dt.timezone.utc, max_concurrency=3
+        ):
             pass
 
     asyncio.run(run())


### PR DESCRIPTION
## Summary
- add cached, concurrent daily theme analysis to mirror conflict analyzer speed ups
- wire API endpoints to new parallel analyzer and stream helpers
- cover new concurrency options with unit tests and ignore analyzer cache file

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f8a772a588325878d1b45f5096f7b