### PR TITLE
fix: render daily themes on correct calendar day

### DIFF
--- a/web/components/DailyThemes.tsx
+++ b/web/components/DailyThemes.tsx
@@ -2,6 +2,11 @@ import { useEffect, useMemo, useState } from "react";
 import Card from "@/components/Card";
 import { getDailyThemes } from "@/lib/api";
 
+function parseLocalDate(dateStr: string): Date {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
+
 interface DayTheme {
   date: string;
   description?: string;
@@ -41,7 +46,9 @@ export default function DailyThemes({ refreshKey }: DailyThemesProps) {
       .then((d) => {
         setDays(d || []);
         if ((d || []).length) {
-          const last = new Date((d as DayTheme[])[(d as DayTheme[]).length - 1].date);
+          const last = parseLocalDate(
+            (d as DayTheme[])[(d as DayTheme[]).length - 1].date,
+          );
           setCurrentMonth(new Date(last.getFullYear(), last.getMonth(), 1));
         }
         setProgress(null);
@@ -58,7 +65,7 @@ export default function DailyThemes({ refreshKey }: DailyThemesProps) {
     if (!currentMonth) return new Map<number, DayTheme>();
     const map = new Map<number, DayTheme>();
     days.forEach((d) => {
-      const dt = new Date(d.date);
+      const dt = parseLocalDate(d.date);
       if (
         dt.getFullYear() === currentMonth.getFullYear() &&
         dt.getMonth() === currentMonth.getMonth()


### PR DESCRIPTION
## Summary
- parse daily theme dates in local time so calendar days match server data

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f910c97ac8325809f359714341a97