### PR TITLE
Fix histogram hook order to prevent React hook mismatch

### DIFF
--- a/web/components/DailyThemes.tsx
+++ b/web/components/DailyThemes.tsx
@@ -88,6 +88,37 @@ export default function DailyThemes({ refreshKey }: DailyThemesProps) {
     return () => window.removeEventListener("keydown", handler);
   }, []);
 
+  const scoreHistOption = useMemo(
+    () => ({
+      backgroundColor: "transparent",
+      textStyle: { color: palette.text },
+      tooltip: {
+        formatter: (p: any) => `${p.name}: ${p.value}`,
+      },
+      xAxis: {
+        type: "category",
+        data: days.map((d) => d.date),
+        axisLabel: { color: palette.text, rotate: 45 },
+        axisLine: { lineStyle: { color: palette.subtext } },
+      },
+      yAxis: {
+        type: "value",
+        name: "Score",
+        max: 100,
+        axisLabel: { color: palette.text },
+        axisLine: { lineStyle: { color: palette.subtext } },
+      },
+      series: [
+        {
+          type: "bar",
+          data: days.map((d) => d.mood_pct ?? 0),
+          itemStyle: { color: palette.series[0] },
+        },
+      ],
+    }),
+    [days, palette]
+  );
+
   if (error) return <div className="text-red-400">{error}</div>;
   if (progress)
     return (
@@ -97,34 +128,6 @@ export default function DailyThemes({ refreshKey }: DailyThemesProps) {
     );
   if (loading) return <div className="text-gray-300">Loading daily themes...</div>;
   if (!days.length) return <div className="text-gray-300">No daily themes yet.</div>;
-
-  const scoreHistOption = useMemo(() => ({
-    backgroundColor: "transparent",
-    textStyle: { color: palette.text },
-    tooltip: {
-      formatter: (p: any) => `${p.name}: ${p.value}`,
-    },
-    xAxis: {
-      type: "category",
-      data: days.map((d) => d.date),
-      axisLabel: { color: palette.text, rotate: 45 },
-      axisLine: { lineStyle: { color: palette.subtext } },
-    },
-    yAxis: {
-      type: "value",
-      name: "Score",
-      max: 100,
-      axisLabel: { color: palette.text },
-      axisLine: { lineStyle: { color: palette.subtext } },
-    },
-    series: [
-      {
-        type: "bar",
-        data: days.map((d) => d.mood_pct ?? 0),
-        itemStyle: { color: palette.series[0] },
-      },
-    ],
-  }), [days, palette]);
 
   const monthLabel = currentMonth?.toLocaleDateString(undefined, {
     year: "numeric",


### PR DESCRIPTION
## Summary
- move score histogram `useMemo` before conditional returns to keep hook execution consistent

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f92a379748325877852f1539cb22a