### PR TITLE
Color daily theme histogram by day and use GPT-5 mini

### DIFF
--- a/services/api/daily_themes.py
+++ b/services/api/daily_themes.py
@@ -115,7 +115,7 @@ def analyze_range(
     client = OpenAI(api_key=api_key)
     try:
         resp = client.responses.create(
-            model="gpt-5-nano",
+            model="gpt-5-mini",
             input=prompt,
             text={"format": {"type": "json_object"}},
         )

--- a/web/components/DailyThemes.tsx
+++ b/web/components/DailyThemes.tsx
@@ -111,8 +111,10 @@ export default function DailyThemes({ refreshKey }: DailyThemesProps) {
       series: [
         {
           type: "bar",
-          data: days.map((d) => d.mood_pct ?? 0),
-          itemStyle: { color: palette.series[0] },
+          data: days.map((d) => ({
+            value: d.mood_pct ?? 0,
+            itemStyle: { color: d.color_hex || palette.series[0] },
+          })),
         },
       ],
     }),


### PR DESCRIPTION
## Summary
- Color daily themes score histogram with per-day colors to mirror calendar gradient
- Switch daily theme analyzer to `gpt-5-mini` model

## Testing
- `npm test` (fails: Missing script: "test")
- `cd services/api && pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f98640b088325b143233cca264c8c