### PR TITLE
Replace daily mood score with relationship health score

### DIFF
--- a/services/api/test_daily_themes.py
+++ b/services/api/test_daily_themes.py
@@ -8,8 +8,8 @@ from themes import THEMES, mood_to_color
 valid_json = (
     """
     {
-      "2024-01-02": {"mood": 75, "color_hex": "#fff", "description": "party", "dominant_theme": {"id": 3}},
-      "2024-01-01": {"mood": 20, "color_hex": "#000", "description": "quiet", "dominant_theme": {"id": 0}}
+      "2024-01-02": {"health_score": 75, "color_hex": "#fff", "description": "party", "dominant_theme": {"id": 3}},
+      "2024-01-01": {"health_score": 20, "color_hex": "#000", "description": "quiet", "dominant_theme": {"id": 0}}
     }
     """.strip()
 )
@@ -28,6 +28,8 @@ def test_parse_days_json_normalizes_and_sorts():
     first, second = out["days"]
     assert first["color_hex"] == mood_to_color(20)
     assert second["color_hex"] == mood_to_color(75)
+    assert first["health_score"] == 20
+    assert second["health_score"] == 75
     assert first["description"] == "quiet"
     assert second["description"] == "party"
     assert first["dominant_theme"]["name"] == THEMES[0]["name"]
@@ -40,7 +42,7 @@ def test_parse_days_json_bad_json_raises():
 
 
 def test_parse_days_json_unknown_theme():
-    bad_theme_json = '{"2024-01-01": {"mood": 10, "dominant_theme": {"id": 99}}}'
+    bad_theme_json = '{"2024-01-01": {"health_score": 10, "dominant_theme": {"id": 99}}}'
     with pytest.raises(DailyThemesError):
         parse_days_json(bad_theme_json, dt.date(2024, 1, 1), dt.date(2024, 1, 1), dt.timezone.utc)
 

--- a/web/components/DailyThemes.tsx
+++ b/web/components/DailyThemes.tsx
@@ -7,8 +7,7 @@ import { getDailyThemes } from "@/lib/api";
 interface DayTheme {
   date: string;
   description?: string;
-  mood?: number;
-  mood_pct?: number;
+  health_score?: number;
   color_hex: string;
   dominant_theme?: { id: number; name: string; icon: string };
 }
@@ -110,7 +109,7 @@ export default function DailyThemes({ refreshKey }: DailyThemesProps) {
       },
       yAxis: {
         type: "value",
-        name: "Score",
+        name: "Health Score",
         max: 100,
         axisLabel: { color: palette.text },
         axisLine: { lineStyle: { color: palette.subtext } },
@@ -119,7 +118,7 @@ export default function DailyThemes({ refreshKey }: DailyThemesProps) {
         {
           type: "bar",
           data: days.map((d) => ({
-            value: d.mood_pct ?? 0,
+            value: d.health_score ?? 0,
             itemStyle: { color: d.color_hex || palette.series[0] },
           })),
         },
@@ -134,7 +133,7 @@ export default function DailyThemes({ refreshKey }: DailyThemesProps) {
       const start = Math.max(0, i - 13);
       const slice = days
         .slice(start, i + 1)
-        .map((d) => d.mood_pct ?? 0);
+        .map((d) => d.health_score ?? 0);
       const avg =
         slice.reduce((sum, v) => sum + v, 0) / (slice.length || 1);
       values.push(parseFloat(avg.toFixed(2)));
@@ -158,7 +157,7 @@ export default function DailyThemes({ refreshKey }: DailyThemesProps) {
       },
       yAxis: {
         type: "value",
-        name: "14d Avg",
+        name: "14d Avg Health Score",
         max: 100,
         axisLabel: { color: palette.text },
         axisLine: { lineStyle: { color: palette.subtext } },
@@ -215,7 +214,9 @@ export default function DailyThemes({ refreshKey }: DailyThemesProps) {
             className="flex-1 flex items-center justify-center text-xl"
             title={[
               info.description,
-              info.mood_pct !== undefined ? `Score: ${info.mood_pct}` : undefined,
+              info.health_score !== undefined
+                ? `Health Score: ${info.health_score}`
+                : undefined,
             ]
               .filter(Boolean)
               .join(" — ")}


### PR DESCRIPTION
## Summary
- rename prompt output from a generic mood percent to a relationship health score
- show health scores in the daily themes calendar and charts
- cover new `health_score` field in daily theme parsing tests

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689fa4166ab0832588098f63358f4780