### PR TITLE
Increase height of daily themes charts

### DIFF
--- a/web/components/DailyThemes.tsx
+++ b/web/components/DailyThemes.tsx
@@ -256,10 +256,10 @@ export default function DailyThemes({ refreshKey }: DailyThemesProps) {
       </div>
       <div className="grid grid-cols-7 gap-1">{cells}</div>
       <div className="mt-4">
-        <Chart option={scoreHistOption} height={200} />
+        <Chart option={scoreHistOption} height={300} />
       </div>
       <div className="mt-4">
-        <Chart option={rollingAvgOption} height={200} />
+        <Chart option={rollingAvgOption} height={300} />
       </div>
     </Card>
   );


### PR DESCRIPTION
## Summary
- enlarge daily theme histogram chart to improve visibility
- enlarge daily theme 14-day rolling average chart

## Testing
- `npm test` *(fails: Missing script: "test"*)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689fa49c238c8325a998b8eaa0b40bc7